### PR TITLE
Add AJAX-based category management with SEO fields

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class CategoryController extends Controller
+{
+    public function index()
+    {
+        $categories = Category::orderByDesc('id')->get();
+        return view('ursbid-admin.category.list', compact('categories'));
+    }
+
+    public function create()
+    {
+        return view('ursbid-admin.category.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:255|unique:category,title',
+            'cat_id' => 'nullable|string|max:200',
+            'post_date' => 'required|date_format:d-m-Y',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $data['slug'] = Str::slug($data['title']);
+
+        if ($request->hasFile('image')) {
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads/category'), $filename);
+            $data['image'] = 'uploads/category/' . $filename;
+        }
+
+        $category = Category::create($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Category created successfully.',
+            'data' => $category,
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $category = Category::findOrFail($id);
+        return view('ursbid-admin.category.edit', compact('category'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $category = Category::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'title' => 'required|string|max:255|unique:category,title,' . $category->id,
+            'cat_id' => 'nullable|string|max:200',
+            'post_date' => 'required|date_format:d-m-Y',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $data['slug'] = Str::slug($data['title']);
+
+        if ($request->hasFile('image')) {
+            if ($category->image && file_exists(public_path($category->image))) {
+                @unlink(public_path($category->image));
+            }
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads/category'), $filename);
+            $data['image'] = 'uploads/category/' . $filename;
+        }
+
+        $category->update($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Category updated successfully.',
+            'data' => $category,
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $category = Category::findOrFail($id);
+        if ($category->image && file_exists(public_path($category->image))) {
+            @unlink(public_path($category->image));
+        }
+        $category->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Category deleted successfully.',
+        ]);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    protected $table = 'category';
+    protected $fillable = [
+        'title',
+        'cat_id',
+        'post_date',
+        'image',
+        'slug',
+        'meta_title',
+        'meta_keywords',
+        'meta_description',
+        'status',
+    ];
+    public $timestamps = false;
+}

--- a/database/migrations/2025_08_03_000000_create_category_table.php
+++ b/database/migrations/2025_08_03_000000_create_category_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('category', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+            $table->string('cat_id', 200)->nullable();
+            $table->string('post_date', 255)->nullable();
+            $table->string('image', 255)->nullable();
+            $table->string('slug', 255)->nullable();
+            $table->string('meta_title')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->string('status', 200)->default('1');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('category');
+    }
+};

--- a/resources/views/ursbid-admin/category/create.blade.php
+++ b/resources/views/ursbid-admin/category/create.blade.php
@@ -1,0 +1,128 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add Category')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="categoryForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" placeholder="Enter Title">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category ID</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="cat_id" class="form-control" placeholder="Enter Category ID">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" placeholder="dd-mm-yyyy">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control" placeholder="Enter Meta Title">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control" placeholder="Enter Meta Keywords">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3" placeholder="Enter Meta Description"></textarea>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12 text-end">
+                                <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+@endpush
+
+@push('scripts')
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
+
+    $.validator.addMethod('dmy', function(value){
+        return /^\d{2}-\d{2}-\d{4}$/.test(value);
+    }, 'Please enter a date in the format dd-mm-yyyy');
+
+    $('#categoryForm').validate({
+        rules:{
+            title:{ required:true },
+            post_date:{ required:true, dmy:true }
+        },
+        submitHandler:function(form){
+            $('#saveBtn').prop('disabled',true).text('Saving...');
+            var formData = new FormData(form);
+            $.ajax({
+                url: '{{ route('super-admin.categories.store') }}',
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: function(res){
+                    toastr.success(res.message);
+                    form.reset();
+                    $('#saveBtn').prop('disabled',false).text('Save');
+                },
+                error: function(xhr){
+                    let err = 'An error occurred';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join('<br>')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').prop('disabled',false).text('Save');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/category/edit.blade.php
+++ b/resources/views/ursbid-admin/category/edit.blade.php
@@ -1,0 +1,133 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Category')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="categoryForm" enctype="multipart/form-data">
+                        @csrf
+                        @method('PUT')
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" value="{{ $category->title }}" placeholder="Enter Title">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category ID</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="cat_id" class="form-control" value="{{ $category->cat_id }}" placeholder="Enter Category ID">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" value="{{ $category->post_date }}" placeholder="dd-mm-yyyy">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                @if($category->image)
+                                <div class="mb-2">
+                                    <img src="{{ asset('public/'.$category->image) }}" alt="Category Image" height="80" style="border:1px solid #ccc;">
+                                </div>
+                                @endif
+                                <input type="file" name="image" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control" value="{{ $category->meta_title }}" placeholder="Enter Meta Title">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control" value="{{ $category->meta_keywords }}" placeholder="Enter Meta Keywords">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3" placeholder="Enter Meta Description">{{ $category->meta_description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12 text-end">
+                                <button type="submit" id="updateBtn" class="btn btn-primary">Update</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+@endpush
+
+@push('scripts')
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
+
+    $.validator.addMethod('dmy', function(value){
+        return /^\d{2}-\d{2}-\d{4}$/.test(value);
+    }, 'Please enter a date in the format dd-mm-yyyy');
+
+    $('#categoryForm').validate({
+        rules:{
+            title:{ required:true },
+            post_date:{ required:true, dmy:true }
+        },
+        submitHandler:function(form){
+            $('#updateBtn').prop('disabled',true).text('Updating...');
+            var formData = new FormData(form);
+            $.ajax({
+                url: '{{ route('super-admin.categories.update', $category->id) }}',
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                success: function(res){
+                    toastr.success(res.message);
+                    $('#updateBtn').prop('disabled',false).text('Update');
+                },
+                error: function(xhr){
+                    let err = 'An error occurred';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join('<br>')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#updateBtn').prop('disabled',false).text('Update');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/category/list.blade.php
+++ b/resources/views/ursbid-admin/category/list.blade.php
@@ -1,0 +1,69 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Categories')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <div class="mb-3 text-end">
+                        <a href="{{ route('super-admin.categories.create') }}" class="btn btn-primary">Add Category</a>
+                    </div>
+                    <table class="table table-bordered">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Title</th>
+                                <th>Post Date</th>
+                                <th>Status</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($categories as $category)
+                            <tr id="row-{{ $category->id }}">
+                                <td>{{ $category->id }}</td>
+                                <td>{{ $category->title }}</td>
+                                <td>{{ $category->post_date }}</td>
+                                <td>{{ $category->status == '1' ? 'Active' : 'Inactive' }}</td>
+                                <td>
+                                    <a href="{{ route('super-admin.categories.edit', $category->id) }}" class="btn btn-sm btn-info">Edit</a>
+                                    <button type="button" data-id="{{ $category->id }}" class="btn btn-sm btn-danger deleteBtn">Delete</button>
+                                </td>
+                            </tr>
+                            @empty
+                            <tr>
+                                <td colspan="5" class="text-center">No categories found.</td>
+                            </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('.deleteBtn').on('click', function(){
+        if(!confirm('Are you sure want to delete?')) return;
+        var id = $(this).data('id');
+        $.ajax({
+            url: '/super-admin/categories/'+id,
+            type: 'DELETE',
+            data: { _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+                $('#row-'+id).remove();
+            },
+            error: function(){
+                toastr.error('Unable to delete record');
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -350,8 +350,16 @@ Route::post('confirm', [\App\Http\Controllers\SellerloginController::class, 'con
 // Guru Maurya Work
 use App\Http\Controllers\Admin\AdminDashboardController;
 use App\Http\Controllers\Admin\WebSettingsController;
+use App\Http\Controllers\Admin\CategoryController as AdminCategoryController;
 Route::get('admin-dashboard', [AdminDashboardController::class, 'index'])->name('super-admin.dashboard');
 Route::get('super-admin/web-settings', [WebSettingsController::class, 'edit'])->name('super-admin.web-settings.edit');
 Route::post('super-admin/web-settings/save', [WebSettingsController::class, 'save'])->name('super-admin.web-settings.save');
+
+Route::get('super-admin/categories', [AdminCategoryController::class, 'index'])->name('super-admin.categories.index');
+Route::get('super-admin/categories/create', [AdminCategoryController::class, 'create'])->name('super-admin.categories.create');
+Route::post('super-admin/categories', [AdminCategoryController::class, 'store'])->name('super-admin.categories.store');
+Route::get('super-admin/categories/{id}/edit', [AdminCategoryController::class, 'edit'])->name('super-admin.categories.edit');
+Route::put('super-admin/categories/{id}', [AdminCategoryController::class, 'update'])->name('super-admin.categories.update');
+Route::delete('super-admin/categories/{id}', [AdminCategoryController::class, 'destroy'])->name('super-admin.categories.destroy');
 
 


### PR DESCRIPTION
## Summary
- implement admin-side category CRUD with image uploads and SEO metadata
- add Blade views with AJAX validation and dd-mm-yyyy date picker
- register super-admin category routes and migration

## Testing
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_688f08047c5883279bf4959b6ad842a3