### PR TITLE
Add AJAX sub category management

### DIFF
--- a/app/Http/Controllers/Admin/SubCategoryController.php
+++ b/app/Http/Controllers/Admin/SubCategoryController.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class SubCategoryController extends Controller
+{
+    /**
+     * Display a listing of the sub categories.
+     */
+    public function index()
+    {
+        $subs = DB::table('sub')
+            ->leftJoin('category', 'sub.cat_id', '=', 'category.id')
+            ->select('sub.*', 'category.title as category_title')
+            ->orderBy('sub.order_by')
+            ->get();
+
+        return view('ursbid-admin.sub_categories.list', compact('subs'));
+    }
+
+    /**
+     * Show the form for creating a new sub category.
+     */
+    public function create()
+    {
+        $categories = DB::table('category')->where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.sub_categories.create', compact('categories'));
+    }
+
+    /**
+     * Store a newly created sub category in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'cat_id' => 'required|integer',
+            'post_date' => 'required|date_format:d-m-Y',
+            'order_by' => 'nullable|integer',
+            'status' => 'required|in:0,1',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5048',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        $exists = DB::table('sub')
+            ->where('cat_id', $validated['cat_id'])
+            ->where('title', $validated['title'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'message' => 'Sub category already exists for this category.',
+                'errors' => ['title' => ['Sub category already exists for this category.']],
+            ], 422);
+        }
+
+        $data = [
+            'title' => $validated['title'],
+            'cat_id' => $validated['cat_id'],
+            'post_date' => $validated['post_date'],
+            'order_by' => $validated['order_by'],
+            'status' => $validated['status'],
+            'slug' => Str::slug($validated['title']),
+            'meta_title' => $request->meta_title,
+            'meta_keywords' => $request->meta_keywords,
+            'meta_description' => $request->meta_description,
+        ];
+
+        $id = DB::table('sub')->insertGetId($data);
+
+        if ($request->hasFile('image')) {
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads'), $filename);
+            DB::table('sub')->where('id', $id)->update(['image' => $filename]);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Sub category created successfully.',
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified sub category.
+     */
+    public function edit($id)
+    {
+        $sub = DB::table('sub')->where('id', $id)->first();
+        if (!$sub) {
+            abort(404);
+        }
+        $categories = DB::table('category')->where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.sub_categories.edit', compact('sub', 'categories'));
+    }
+
+    /**
+     * Update the specified sub category in storage.
+     */
+    public function update(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'cat_id' => 'required|integer',
+            'post_date' => 'required|date_format:d-m-Y',
+            'order_by' => 'nullable|integer',
+            'status' => 'required|in:0,1',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5048',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        $exists = DB::table('sub')
+            ->where('cat_id', $validated['cat_id'])
+            ->where('title', $validated['title'])
+            ->where('id', '!=', $id)
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'message' => 'Sub category already exists for this category.',
+                'errors' => ['title' => ['Sub category already exists for this category.']],
+            ], 422);
+        }
+
+        $sub = DB::table('sub')->where('id', $id)->first();
+        if (!$sub) {
+            return response()->json(['message' => 'Sub category not found.'], 404);
+        }
+
+        $data = [
+            'title' => $validated['title'],
+            'cat_id' => $validated['cat_id'],
+            'post_date' => $validated['post_date'],
+            'order_by' => $validated['order_by'],
+            'status' => $validated['status'],
+            'slug' => Str::slug($validated['title']),
+            'meta_title' => $request->meta_title,
+            'meta_keywords' => $request->meta_keywords,
+            'meta_description' => $request->meta_description,
+        ];
+
+        if ($request->hasFile('image')) {
+            if (!empty($sub->image)) {
+                $path = public_path('uploads/' . $sub->image);
+                if (File::exists($path)) {
+                    File::delete($path);
+                }
+            }
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads'), $filename);
+            $data['image'] = $filename;
+        }
+
+        DB::table('sub')->where('id', $id)->update($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Sub category updated successfully.',
+        ]);
+    }
+
+    /**
+     * Remove the specified sub category from storage.
+     */
+    public function destroy($id)
+    {
+        $sub = DB::table('sub')->where('id', $id)->first();
+        if (!$sub) {
+            return response()->json(['message' => 'Sub category not found.'], 404);
+        }
+
+        if (!empty($sub->image)) {
+            $path = public_path('uploads/' . $sub->image);
+            if (File::exists($path)) {
+                File::delete($path);
+            }
+        }
+
+        DB::table('sub')->where('id', $id)->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Sub category deleted successfully.',
+        ]);
+    }
+}

--- a/database/migrations/2025_08_03_000000_add_seo_fields_to_sub_table.php
+++ b/database/migrations/2025_08_03_000000_add_seo_fields_to_sub_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sub', function (Blueprint $table) {
+            $table->string('meta_title')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sub', function (Blueprint $table) {
+            $table->dropColumn(['meta_title', 'meta_keywords', 'meta_description']);
+        });
+    }
+};

--- a/resources/views/ursbid-admin/sub_categories/create.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/create.blade.php
@@ -1,0 +1,143 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add Sub Category')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="subCategoryForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="cat_id" class="form-control" required>
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $cat)
+                                        <option value="{{ $cat->id }}">{{ $cat->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" placeholder="dd-mm-yyyy" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Order By</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="number" name="order_by" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1">Active</option>
+                                    <option value="0">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control" accept="image/*">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3"></textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script>
+$(function(){
+    $('#subCategoryForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()) return;
+        $('#saveBtn').attr('disabled', true).text('Saving...');
+        $.ajax({
+            url: "{{ route('super-admin.sub-categories.store') }}",
+            method: 'POST',
+            data: new FormData(this),
+            processData: false,
+            contentType: false,
+            success: function(res){
+                toastr.success(res.message);
+                $('#subCategoryForm')[0].reset();
+                $('#saveBtn').attr('disabled', false).text('Save');
+            },
+            error: function(xhr){
+                let err = 'Error saving data';
+                if(xhr.responseJSON && xhr.responseJSON.errors){
+                    err = Object.values(xhr.responseJSON.errors).map(e => e.join(', ')).join('<br>');
+                }
+                toastr.error(err, 'Error');
+                $('#saveBtn').attr('disabled', false).text('Save');
+            }
+        });
+    });
+
+    function validateForm(){
+        let title = $('input[name="title"]').val().trim();
+        let cat = $('select[name="cat_id"]').val();
+        let date = $('#post_date').val().trim();
+        let dateRegex = /^\d{2}-\d{2}-\d{4}$/;
+        if(title === '' || cat === '' || date === '' || !dateRegex.test(date)){
+            toastr.error('Please fill required fields with valid data');
+            return false;
+        }
+        return true;
+    }
+});
+</script>
+@endpush
+@endsection

--- a/resources/views/ursbid-admin/sub_categories/edit.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/edit.blade.php
@@ -1,0 +1,147 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Sub Category')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="subCategoryForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" value="{{ $sub->title }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="cat_id" class="form-control" required>
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $cat)
+                                        <option value="{{ $cat->id }}" {{ $sub->cat_id == $cat->id ? 'selected' : '' }}>{{ $cat->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" value="{{ $sub->post_date }}" placeholder="dd-mm-yyyy" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Order By</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="number" name="order_by" class="form-control" value="{{ $sub->order_by }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1" {{ $sub->status == 1 ? 'selected' : '' }}>Active</option>
+                                    <option value="0" {{ $sub->status == 0 ? 'selected' : '' }}>Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                @if(!empty($sub->image))
+                                    <div class="mb-2">
+                                        <img src="{{ asset('public/uploads/' . $sub->image) }}" alt="Image" height="80" style="border:1px solid #ccc;">
+                                    </div>
+                                @endif
+                                <input type="file" name="image" class="form-control" accept="image/*">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control" value="{{ $sub->meta_title }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control" value="{{ $sub->meta_keywords }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3">{{ $sub->meta_description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Update</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script>
+$(function(){
+    $('#subCategoryForm').on('submit', function(e){
+        e.preventDefault();
+        if(!validateForm()) return;
+        $('#saveBtn').attr('disabled', true).text('Updating...');
+        $.ajax({
+            url: "{{ route('super-admin.sub-categories.update', $sub->id) }}",
+            method: 'POST',
+            data: new FormData(this),
+            processData: false,
+            contentType: false,
+            success: function(res){
+                toastr.success(res.message);
+                window.location.href = "{{ route('super-admin.sub-categories.index') }}";
+            },
+            error: function(xhr){
+                let err = 'Error updating data';
+                if(xhr.responseJSON && xhr.responseJSON.errors){
+                    err = Object.values(xhr.responseJSON.errors).map(e => e.join(', ')).join('<br>');
+                }
+                toastr.error(err, 'Error');
+                $('#saveBtn').attr('disabled', false).text('Update');
+            }
+        });
+    });
+
+    function validateForm(){
+        let title = $('input[name="title"]').val().trim();
+        let cat = $('select[name="cat_id"]').val();
+        let date = $('#post_date').val().trim();
+        let dateRegex = /^\d{2}-\d{2}-\d{4}$/;
+        if(title === '' || cat === '' || date === '' || !dateRegex.test(date)){
+            toastr.error('Please fill required fields with valid data');
+            return false;
+        }
+        return true;
+    }
+});
+</script>
+@endpush
+@endsection

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -1,0 +1,72 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Sub Categories')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <div class="mb-3 text-end">
+                        <a href="{{ route('super-admin.sub-categories.create') }}" class="btn btn-primary">Add Sub Category</a>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Title</th>
+                                    <th>Category</th>
+                                    <th>Post Date</th>
+                                    <th>Status</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($subs as $sub)
+                                    <tr id="row-{{ $sub->id }}">
+                                        <td>{{ $sub->id }}</td>
+                                        <td>{{ $sub->title }}</td>
+                                        <td>{{ $sub->category_title }}</td>
+                                        <td>{{ $sub->post_date }}</td>
+                                        <td>{{ $sub->status == 1 ? 'Active' : 'Inactive' }}</td>
+                                        <td>
+                                            <a href="{{ route('super-admin.sub-categories.edit', $sub->id) }}" class="btn btn-sm btn-info">Edit</a>
+                                            <button type="button" class="btn btn-sm btn-danger delete-btn" data-url="{{ route('super-admin.sub-categories.destroy', $sub->id) }}">Delete</button>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="6" class="text-center">No records found</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script>
+$(function(){
+    $('.delete-btn').on('click', function(){
+        if(!confirm('Are you sure?')) return;
+        let url = $(this).data('url');
+        $.ajax({
+            url: url,
+            method: 'POST',
+            data: {_method:'DELETE', _token:'{{ csrf_token() }}'},
+            success: function(res){
+                toastr.success(res.message);
+                $('#row-'+url.split('/').pop()).remove();
+            },
+            error: function(){
+                toastr.error('Delete failed', 'Error');
+            }
+        });
+    });
+});
+</script>
+@endpush
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -350,8 +350,15 @@ Route::post('confirm', [\App\Http\Controllers\SellerloginController::class, 'con
 // Guru Maurya Work
 use App\Http\Controllers\Admin\AdminDashboardController;
 use App\Http\Controllers\Admin\WebSettingsController;
+use App\Http\Controllers\Admin\SubCategoryController;
 Route::get('admin-dashboard', [AdminDashboardController::class, 'index'])->name('super-admin.dashboard');
 Route::get('super-admin/web-settings', [WebSettingsController::class, 'edit'])->name('super-admin.web-settings.edit');
 Route::post('super-admin/web-settings/save', [WebSettingsController::class, 'save'])->name('super-admin.web-settings.save');
 
 
+Route::get('super-admin/sub-categories', [SubCategoryController::class, 'index'])->name('super-admin.sub-categories.index');
+Route::get('super-admin/sub-categories/create', [SubCategoryController::class, 'create'])->name('super-admin.sub-categories.create');
+Route::post('super-admin/sub-categories', [SubCategoryController::class, 'store'])->name('super-admin.sub-categories.store');
+Route::get('super-admin/sub-categories/{id}/edit', [SubCategoryController::class, 'edit'])->name('super-admin.sub-categories.edit');
+Route::post('super-admin/sub-categories/{id}', [SubCategoryController::class, 'update'])->name('super-admin.sub-categories.update');
+Route::delete('super-admin/sub-categories/{id}', [SubCategoryController::class, 'destroy'])->name('super-admin.sub-categories.destroy');


### PR DESCRIPTION
## Summary
- add SubCategoryController with CRUD and SEO fields
- create AJAX-enabled sub category create/edit/list views
- register super-admin routes and migration for SEO metadata

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f08f2d3108327a09abbf66eaf1480