### PR TITLE
Remove Category ID field from admin category forms

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -25,7 +25,6 @@ class CategoryController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'title' => 'required|string|max:255|unique:category,title',
-            'cat_id' => 'nullable|string|max:200',
             'post_date' => 'required|date_format:d-m-Y',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
             'meta_title' => 'nullable|string|max:255',
@@ -71,7 +70,6 @@ class CategoryController extends Controller
 
         $validator = Validator::make($request->all(), [
             'title' => 'required|string|max:255|unique:category,title,' . $category->id,
-            'cat_id' => 'nullable|string|max:200',
             'post_date' => 'required|date_format:d-m-Y',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
             'meta_title' => 'nullable|string|max:255',

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -9,7 +9,6 @@ class Category extends Model
     protected $table = 'category';
     protected $fillable = [
         'title',
-        'cat_id',
         'post_date',
         'image',
         'slug',

--- a/resources/views/ursbid-admin/category/create.blade.php
+++ b/resources/views/ursbid-admin/category/create.blade.php
@@ -33,14 +33,6 @@
                         </div>
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Category ID</label>
-                            </div>
-                            <div class="col-md-8">
-                                <input type="text" name="cat_id" class="form-control" placeholder="Enter Category ID">
-                            </div>
-                        </div>
-                        <div class="row mb-3 align-items-center">
-                            <div class="col-md-4">
                                 <label class="form-label fw-semibold">Post Date</label>
                             </div>
                             <div class="col-md-8">

--- a/resources/views/ursbid-admin/category/edit.blade.php
+++ b/resources/views/ursbid-admin/category/edit.blade.php
@@ -34,14 +34,6 @@
                         </div>
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Category ID</label>
-                            </div>
-                            <div class="col-md-8">
-                                <input type="text" name="cat_id" class="form-control" value="{{ $category->cat_id }}" placeholder="Enter Category ID">
-                            </div>
-                        </div>
-                        <div class="row mb-3 align-items-center">
-                            <div class="col-md-4">
                                 <label class="form-label fw-semibold">Post Date</label>
                             </div>
                             <div class="col-md-8">


### PR DESCRIPTION
## Summary
- drop Category ID input from super-admin category create and edit views
- remove `cat_id` handling from category controller and model

## Testing
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*
- `composer install --ignore-platform-reqs` *(fails: `@php artisan package:discover --ansi` returned with error code 255)*
- `./vendor/bin/phpunit` *(fails: Cannot use App\Http\Controllers\Admin\AdminDashboardController as AdminDashboardController because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_688f12ac5fb0832785bdc8dacd608eb7