### PR TITLE
Ensure category forms redirect on successful AJAX save

### DIFF
--- a/resources/views/ursbid-admin/category/create.blade.php
+++ b/resources/views/ursbid-admin/category/create.blade.php
@@ -114,9 +114,13 @@ $(function(){
                 processData: false,
                 contentType: false,
                 success: function(res){
-                    toastr.success(res.message);
-                    form.reset();
-                    $('#saveBtn').prop('disabled',false).text('Save');
+                    if(res.status === 'success'){
+                        toastr.success(res.message);
+                        window.location.href = '{{ route('super-admin.categories.index') }}';
+                    } else {
+                        toastr.error(res.message || 'An error occurred');
+                        $('#saveBtn').prop('disabled',false).text('Save');
+                    }
                 },
                 error: function(xhr){
                     let err = 'An error occurred';

--- a/resources/views/ursbid-admin/category/edit.blade.php
+++ b/resources/views/ursbid-admin/category/edit.blade.php
@@ -120,8 +120,13 @@ $(function(){
                 processData: false,
                 contentType: false,
                 success: function(res){
-                    toastr.success(res.message);
-                    $('#updateBtn').prop('disabled',false).text('Update');
+                    if(res.status === 'success'){
+                        toastr.success(res.message);
+                        window.location.href = '{{ route('super-admin.categories.index') }}';
+                    } else {
+                        toastr.error(res.message || 'An error occurred');
+                        $('#updateBtn').prop('disabled',false).text('Update');
+                    }
                 },
                 error: function(xhr){
                     let err = 'An error occurred';


### PR DESCRIPTION
## Summary
- Redirect to categories list after creating a category via AJAX
- Redirect to categories list after updating a category via AJAX

## Testing
- `composer install --ignore-platform-req=php --no-interaction --no-progress` *(fails: Cannot use App\Http\Controllers\Admin\AdminDashboardController as AdminDashboardController because the name is already in use)*
- `vendor/bin/phpunit` *(fails: Cannot use App\Http\Controllers\Admin\AdminDashboardController as AdminDashboardController because the name is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_688f158c3f188327a74c37a7614653c8