### PR TITLE
Add pagination controls to subcategory listings

### DIFF
--- a/app/Http/Controllers/Admin/SubCategoryController.php
+++ b/app/Http/Controllers/Admin/SubCategoryController.php
@@ -13,15 +13,17 @@ class SubCategoryController extends Controller
     /**
      * Display a listing of the sub categories.
      */
-    public function index()
+    public function index(Request $request)
     {
+        $perPage = $request->get('per_page', 10);
+
         $subs = DB::table('sub')
             ->leftJoin('category', 'sub.cat_id', '=', 'category.id')
             ->select('sub.*', 'category.title as category_title')
             ->orderBy('sub.order_by')
-            ->get();
+            ->paginate($perPage);
 
-        return view('ursbid-admin.sub_categories.list', compact('subs'));
+        return view('ursbid-admin.sub_categories.list', compact('subs', 'perPage'));
     }
 
     /**

--- a/app/Http/Controllers/SubController.php
+++ b/app/Http/Controllers/SubController.php
@@ -65,7 +65,7 @@ class SubController extends Controller
     public function view(Request $request)
 {
     $keyword = $request->input('keyword');
-    $recordsPerPage = $request->input('r_page', 15);
+    $recordsPerPage = $request->input('r_page', 10);
     
     $query = DB::table('sub')
         ->join('category', 'sub.cat_id', '=', 'category.id')

--- a/resources/views/admin/sub/list.blade.php
+++ b/resources/views/admin/sub/list.blade.php
@@ -52,9 +52,13 @@
                             <div class="col-md-2 no-padding-left">
                                 <div class="form-group">
                                     <select class="form-control select2" name="r_page">
+                                        <option value="10" {{ $data['r_page'] == 10 ? 'selected' : '' }}> 10 Records Per
+                                            Page</option>
                                         <option value="25" {{ $data['r_page'] == 25 ? 'selected' : '' }}> 25 Records Per
                                             Page</option>
                                         <option value="50" {{ $data['r_page'] == 50 ? 'selected' : '' }}> 50 Records Per
+                                            Page</option>
+                                        <option value="75" {{ $data['r_page'] == 75 ? 'selected' : '' }}> 75 Records Per
                                             Page</option>
                                         <option value="100" {{ $data['r_page'] == 100 ? 'selected' : '' }}> 100 Records
                                             Per Page</option>

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -5,10 +5,24 @@
     <div class="row">
         <div class="col-md-12">
             <div class="card">
-                <div class="card-body">
-                    <div class="mb-3 text-end">
-                        <a href="{{ route('super-admin.sub-categories.create') }}" class="btn btn-primary">Add Sub Category</a>
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <div>
+                        <h4 class="card-title mb-0">All Sub Categories List</h4>
                     </div>
+                    <a href="{{ route('super-admin.sub-categories.create') }}" class="btn btn-sm btn-primary">Add Sub Category</a>
+                </div>
+                <div class="card-body">
+                    <form method="get" class="row mb-3">
+                        <div class="col-md-2">
+                            <select name="per_page" class="form-select" onchange="this.form.submit()">
+                                <option value="10" {{ $perPage == 10 ? 'selected' : '' }}>10</option>
+                                <option value="25" {{ $perPage == 25 ? 'selected' : '' }}>25</option>
+                                <option value="50" {{ $perPage == 50 ? 'selected' : '' }}>50</option>
+                                <option value="75" {{ $perPage == 75 ? 'selected' : '' }}>75</option>
+                                <option value="100" {{ $perPage == 100 ? 'selected' : '' }}>100</option>
+                            </select>
+                        </div>
+                    </form>
                     <div class="table-responsive">
                         <table class="table table-bordered">
                             <thead>
@@ -27,7 +41,7 @@
                                         <td>{{ $sub->id }}</td>
                                         <td>{{ $sub->title }}</td>
                                         <td>{{ $sub->category_title }}</td>
-                                        <td>{{ $sub->post_date }}</td>
+                                        <td>{{ \Carbon\Carbon::createFromFormat('d-m-Y', $sub->post_date)->format('d-m-Y') }}</td>
                                         <td>{{ $sub->status == 1 ? 'Active' : 'Inactive' }}</td>
                                         <td>
                                             <a href="{{ route('super-admin.sub-categories.edit', $sub->id) }}" class="btn btn-sm btn-info">Edit</a>
@@ -42,6 +56,9 @@
                             </tbody>
                         </table>
                     </div>
+                </div>
+                <div class="card-footer">
+                    {{ $subs->withQueryString()->links() }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- paginate super-admin sub categories with configurable page sizes
- allow admin sub category lists to show 10-100 records per page

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/ursbid-work/vendor/autoload.php')*
- `composer install` *(fails: nette/schema requires php 7.1 - 8.3, current php version 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_688f1bf67c5083279648c6bac9d3c910