### PR TITLE
Implement product CMS with AJAX validations and SEO

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $perPage = $request->get('per_page', 10);
+
+        $products = DB::table('product')
+            ->leftJoin('category', 'product.cat_id', '=', 'category.id')
+            ->leftJoin('sub', 'product.sub_id', '=', 'sub.id')
+            ->select('product.*', 'category.title as category_title', 'sub.title as sub_title')
+            ->orderBy('product.order_by')
+            ->paginate($perPage);
+
+        return view('ursbid-admin.products.list', compact('products', 'perPage'));
+    }
+
+    public function create()
+    {
+        $categories = DB::table('category')->where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.products.create', compact('categories'));
+    }
+
+    public function getSubCategories(Request $request)
+    {
+        $subs = DB::table('sub')
+            ->where('cat_id', $request->cat_id)
+            ->where('status', 1)
+            ->orderBy('title')
+            ->get();
+        return response()->json($subs);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'cat_id' => 'required|integer',
+            'sub_id' => 'required|integer',
+            'post_date' => 'required|date_format:d-m-Y',
+            'order_by' => 'nullable|integer',
+            'status' => 'required|in:0,1',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5048',
+            'description' => 'nullable|string',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        $exists = DB::table('product')
+            ->where('cat_id', $validated['cat_id'])
+            ->where('sub_id', $validated['sub_id'])
+            ->where('title', $validated['title'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'message' => 'Product already exists for this sub category.',
+                'errors' => ['title' => ['Product already exists for this sub category.']],
+            ], 422);
+        }
+
+        $data = [
+            'title' => $validated['title'],
+            'cat_id' => $validated['cat_id'],
+            'sub_id' => $validated['sub_id'],
+            'post_date' => $validated['post_date'],
+            'order_by' => $validated['order_by'],
+            'status' => $validated['status'],
+            'description' => $request->description,
+            'slug' => Str::slug($validated['title']),
+            'meta_title' => $request->meta_title,
+            'meta_keywords' => $request->meta_keywords,
+            'meta_description' => $request->meta_description,
+            'user_id' => 0,
+            'user_type' => 'Admin',
+            'insert_by' => 'Admin',
+            'update_by' => 'Admin',
+        ];
+
+        $id = DB::table('product')->insertGetId($data);
+
+        if ($request->hasFile('image')) {
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $uploadPath = public_path('uploads/product');
+            if (!file_exists($uploadPath)) {
+                mkdir($uploadPath, 0777, true);
+            }
+            $file->move($uploadPath, $filename);
+            DB::table('product')->where('id', $id)->update([
+                'image' => 'uploads/product/' . $filename,
+            ]);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Product created successfully.',
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $product = DB::table('product')->where('id', $id)->first();
+        if (!$product) {
+            abort(404);
+        }
+        $categories = DB::table('category')->where('status', 1)->orderBy('title')->get();
+        $subCategories = DB::table('sub')->where('cat_id', $product->cat_id)->where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.products.edit', compact('product', 'categories', 'subCategories'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'cat_id' => 'required|integer',
+            'sub_id' => 'required|integer',
+            'post_date' => 'required|date_format:d-m-Y',
+            'order_by' => 'nullable|integer',
+            'status' => 'required|in:0,1',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:5048',
+            'description' => 'nullable|string',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        $exists = DB::table('product')
+            ->where('cat_id', $validated['cat_id'])
+            ->where('sub_id', $validated['sub_id'])
+            ->where('title', $validated['title'])
+            ->where('id', '!=', $id)
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'message' => 'Product already exists for this sub category.',
+                'errors' => ['title' => ['Product already exists for this sub category.']],
+            ], 422);
+        }
+
+        $product = DB::table('product')->where('id', $id)->first();
+        if (!$product) {
+            return response()->json(['message' => 'Product not found.'], 404);
+        }
+
+        $data = [
+            'title' => $validated['title'],
+            'cat_id' => $validated['cat_id'],
+            'sub_id' => $validated['sub_id'],
+            'post_date' => $validated['post_date'],
+            'order_by' => $validated['order_by'],
+            'status' => $validated['status'],
+            'description' => $request->description,
+            'slug' => Str::slug($validated['title']),
+            'meta_title' => $request->meta_title,
+            'meta_keywords' => $request->meta_keywords,
+            'meta_description' => $request->meta_description,
+            'update_by' => 'Admin',
+        ];
+
+        if ($request->hasFile('image')) {
+            if (!empty($product->image) && file_exists(public_path($product->image))) {
+                @unlink(public_path($product->image));
+            }
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $uploadPath = public_path('uploads/product');
+            if (!file_exists($uploadPath)) {
+                mkdir($uploadPath, 0777, true);
+            }
+            $file->move($uploadPath, $filename);
+            $data['image'] = 'uploads/product/' . $filename;
+        }
+
+        DB::table('product')->where('id', $id)->update($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Product updated successfully.',
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $product = DB::table('product')->where('id', $id)->first();
+        if (!$product) {
+            return response()->json(['message' => 'Product not found.'], 404);
+        }
+
+        if (!empty($product->image) && file_exists(public_path($product->image))) {
+            File::delete(public_path($product->image));
+        }
+
+        DB::table('product')->where('id', $id)->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Product deleted successfully.',
+        ]);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    protected $table = 'product';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'cat_id',
+        'sub_id',
+        'super_id',
+        'title',
+        'description',
+        'image',
+        'user_type',
+        'insert_by',
+        'update_by',
+        'slug',
+        'meta_title',
+        'meta_keywords',
+        'meta_description',
+        'status',
+        'order_by',
+        'post_date',
+    ];
+}

--- a/database/migrations/2025_08_04_000000_create_product_table.php
+++ b/database/migrations/2025_08_04_000000_create_product_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedInteger('cat_id')->nullable();
+            $table->unsignedInteger('sub_id')->nullable();
+            $table->unsignedInteger('super_id')->nullable();
+            $table->string('title', 255)->nullable();
+            $table->text('description')->nullable();
+            $table->string('image', 255)->nullable();
+            $table->string('user_type', 255)->nullable();
+            $table->string('insert_by', 255)->nullable();
+            $table->string('update_by', 255)->nullable();
+            $table->string('slug', 255)->nullable();
+            $table->string('post_date', 255)->nullable();
+            $table->string('meta_title')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->string('status', 200)->default('1');
+            $table->integer('order_by')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product');
+    }
+};

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -82,6 +82,9 @@
                           <li class="sub-nav-item">
                                <a class="sub-nav-link {{ request()->is('super-admin/sub-categories*') ? 'active' : '' }}" href="{{ route('super-admin.sub-categories.index') }}">Sub Category</a>
                           </li>
+                          <li class="sub-nav-item">
+                               <a class="sub-nav-link {{ request()->is('super-admin/products*') ? 'active' : '' }}" href="{{ route('super-admin.products.index') }}">Product</a>
+                          </li>
                      </ul>
                 </div>
            </li>

--- a/resources/views/ursbid-admin/products/create.blade.php
+++ b/resources/views/ursbid-admin/products/create.blade.php
@@ -1,0 +1,180 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add Product')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="productForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="cat_id" id="cat_id" class="form-control" required>
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $cat)
+                                        <option value="{{ $cat->id }}">{{ $cat->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Sub Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="sub_id" id="sub_id" class="form-control" required>
+                                    <option value="">Select Sub Category</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" placeholder="dd-mm-yyyy" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Order By</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="number" name="order_by" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1">Active</option>
+                                    <option value="0">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control" accept="image/*">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="description" class="form-control" rows="3"></textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3"></textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+@endpush
+
+@push('scripts')
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
+
+    $.validator.addMethod('dmy', function(value){
+        return /^\d{2}-\d{2}-\d{4}$/.test(value);
+    }, 'Please enter a date in the format dd-mm-yyyy');
+
+    $('#cat_id').on('change', function(){
+        $('#sub_id').html('<option value="">Select Sub Category</option>');
+        var cat_id = $(this).val();
+        if(cat_id){
+            $.get('{{ route('super-admin.products.get-subcategories') }}', {cat_id:cat_id}, function(res){
+                $.each(res, function(i, item){
+                    $('#sub_id').append('<option value="'+item.id+'">'+item.title+'</option>');
+                });
+            });
+        }
+    });
+
+    $('#productForm').validate({
+        rules:{
+            title:{ required:true },
+            cat_id:{ required:true },
+            sub_id:{ required:true },
+            post_date:{ required:true, dmy:true }
+        },
+        submitHandler:function(form){
+            $('#saveBtn').attr('disabled', true).text('Saving...');
+            $.ajax({
+                url: '{{ route('super-admin.products.store') }}',
+                type: 'POST',
+                data: new FormData(form),
+                processData:false,
+                contentType:false,
+                success: function(res){
+                    toastr.success(res.message);
+                    form.reset();
+                    $('#saveBtn').attr('disabled', false).text('Save');
+                },
+                error: function(xhr){
+                    let err = 'Error saving data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e => e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').attr('disabled', false).text('Save');
+                }
+            });
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/products/edit.blade.php
+++ b/resources/views/ursbid-admin/products/edit.blade.php
@@ -1,0 +1,185 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Product')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="productForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" value="{{ $product->title }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="cat_id" id="cat_id" class="form-control" required>
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $cat)
+                                        <option value="{{ $cat->id }}" {{ $product->cat_id == $cat->id ? 'selected' : '' }}>{{ $cat->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Sub Category<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="sub_id" id="sub_id" class="form-control" required>
+                                    <option value="">Select Sub Category</option>
+                                    @foreach($subCategories as $sub)
+                                        <option value="{{ $sub->id }}" {{ $product->sub_id == $sub->id ? 'selected' : '' }}>{{ $sub->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="post_date" id="post_date" class="form-control" value="{{ $product->post_date }}" placeholder="dd-mm-yyyy" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Order By</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="number" name="order_by" class="form-control" value="{{ $product->order_by }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1" {{ $product->status == 1 ? 'selected' : '' }}>Active</option>
+                                    <option value="0" {{ $product->status == 0 ? 'selected' : '' }}>Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control" accept="image/*">
+                                @if($product->image)
+                                    <img src="/{{ $product->image }}" alt="Image" class="img-thumbnail mt-2" style="max-width:150px;">
+                                @endif
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="description" class="form-control" rows="3">{{ $product->description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control" value="{{ $product->meta_title }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control" value="{{ $product->meta_keywords }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3">{{ $product->meta_description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Update</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('styles')
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+@endpush
+
+@push('scripts')
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
+
+    $.validator.addMethod('dmy', function(value){
+        return /^\d{2}-\d{2}-\d{4}$/.test(value);
+    }, 'Please enter a date in the format dd-mm-yyyy');
+
+    $('#cat_id').on('change', function(){
+        $('#sub_id').html('<option value="">Select Sub Category</option>');
+        var cat_id = $(this).val();
+        if(cat_id){
+            $.get('{{ route('super-admin.products.get-subcategories') }}', {cat_id:cat_id}, function(res){
+                $.each(res, function(i, item){
+                    $('#sub_id').append('<option value="'+item.id+'">'+item.title+'</option>');
+                });
+            });
+        }
+    });
+
+    $('#productForm').validate({
+        rules:{
+            title:{ required:true },
+            cat_id:{ required:true },
+            sub_id:{ required:true },
+            post_date:{ required:true, dmy:true }
+        },
+        submitHandler:function(form){
+            $('#saveBtn').attr('disabled', true).text('Updating...');
+            $.ajax({
+                url: '{{ route('super-admin.products.update', $product->id) }}',
+                type: 'POST',
+                data: new FormData(form),
+                processData:false,
+                contentType:false,
+                success: function(res){
+                    toastr.success(res.message);
+                    $('#saveBtn').attr('disabled', false).text('Update');
+                },
+                error: function(xhr){
+                    let err = 'Error updating data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e => e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').attr('disabled', false).text('Update');
+                }
+            });
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/products/list.blade.php
+++ b/resources/views/ursbid-admin/products/list.blade.php
@@ -1,0 +1,97 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Products')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <div>
+                        <h4 class="card-title mb-0">All Products List</h4>
+                    </div>
+                    <a href="{{ route('super-admin.products.create') }}" class="btn btn-sm btn-primary">Add Product</a>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Title</th>
+                                    <th>Category</th>
+                                    <th>Sub Category</th>
+                                    <th>Post Date</th>
+                                    <th>Status</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($products as $product)
+                                    <tr id="row-{{ $product->id }}">
+                                        <td>{{ $product->id }}</td>
+                                        <td>{{ $product->title }}</td>
+                                        <td>{{ $product->category_title }}</td>
+                                        <td>{{ $product->sub_title }}</td>
+                                        <td>{{ $product->post_date ? \Carbon\Carbon::parse($product->post_date)->format('d-m-Y') : '' }}</td>
+                                        <td>{{ $product->status == 1 ? 'Active' : 'Inactive' }}</td>
+                                        <td>
+                                            <a href="{{ route('super-admin.products.edit', $product->id) }}" class="btn btn-sm btn-info">Edit</a>
+                                            <button type="button" class="btn btn-sm btn-danger delete-btn" data-url="{{ route('super-admin.products.destroy', $product->id) }}">Delete</button>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="7" class="text-center">No records found</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="card-footer d-flex flex-wrap justify-content-between align-items-center">
+                    <form method="get" class="d-flex align-items-center mb-2 mb-md-0">
+                        <label class="me-2 mb-0">Show</label>
+                        <select name="per_page" class="form-select form-select-sm w-auto" onchange="this.form.submit()">
+                            <option value="10" {{ $perPage == 10 ? 'selected' : '' }}>10</option>
+                            <option value="25" {{ $perPage == 25 ? 'selected' : '' }}>25</option>
+                            <option value="50" {{ $perPage == 50 ? 'selected' : '' }}>50</option>
+                            <option value="75" {{ $perPage == 75 ? 'selected' : '' }}>75</option>
+                            <option value="100" {{ $perPage == 100 ? 'selected' : '' }}>100</option>
+                        </select>
+                        <span class="ms-2">entries</span>
+                        <span class="ms-3 text-muted">
+                            Showing {{ $products->firstItem() ?? 0 }} to {{ $products->lastItem() ?? 0 }} of {{ $products->total() }} entries
+                        </span>
+                    </form>
+                    <div>
+                        {{ $products->withQueryString()->links('pagination::bootstrap-5') }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('scripts')
+<script>
+$(function(){
+    $('.delete-btn').on('click', function(){
+        if(!confirm('Are you sure?')) return;
+        let url = $(this).data('url');
+        $.ajax({
+            url: url,
+            method: 'POST',
+            data: {_method:'DELETE', _token:'{{ csrf_token() }}'},
+            success: function(res){
+                toastr.success(res.message);
+                $('#row-'+url.split('/').pop()).remove();
+            },
+            error: function(){
+                toastr.error('Delete failed', 'Error');
+            }
+        });
+    });
+});
+</script>
+@endpush
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\EmailController;
 use App\Http\Controllers\Admin\AdminDashboardController;
 use App\Http\Controllers\Admin\WebSettingsController;
 use App\Http\Controllers\Admin\CategoryController as AdminCategoryController;
+use App\Http\Controllers\Admin\SubCategoryController;
+use App\Http\Controllers\Admin\ProductController as AdminProductController;
 
 
 /*
@@ -352,10 +354,6 @@ Route::post('confirm', [\App\Http\Controllers\SellerloginController::class, 'con
 
 // Guru Maurya Work
 
-use App\Http\Controllers\Admin\AdminDashboardController;
-use App\Http\Controllers\Admin\WebSettingsController;
-use App\Http\Controllers\Admin\SubCategoryController;
-
 Route::prefix('super-admin')->group(function () {
     Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('super-admin.dashboard');
     Route::get('web-settings', [WebSettingsController::class, 'edit'])->name('super-admin.web-settings.edit');
@@ -375,3 +373,11 @@ Route::post('super-admin/sub-categories', [SubCategoryController::class, 'store'
 Route::get('super-admin/sub-categories/{id}/edit', [SubCategoryController::class, 'edit'])->name('super-admin.sub-categories.edit');
 Route::post('super-admin/sub-categories/{id}', [SubCategoryController::class, 'update'])->name('super-admin.sub-categories.update');
 Route::delete('super-admin/sub-categories/{id}', [SubCategoryController::class, 'destroy'])->name('super-admin.sub-categories.destroy');
+
+Route::get('super-admin/products', [AdminProductController::class, 'index'])->name('super-admin.products.index');
+Route::get('super-admin/products/create', [AdminProductController::class, 'create'])->name('super-admin.products.create');
+Route::post('super-admin/products', [AdminProductController::class, 'store'])->name('super-admin.products.store');
+Route::get('super-admin/products/{id}/edit', [AdminProductController::class, 'edit'])->name('super-admin.products.edit');
+Route::post('super-admin/products/{id}', [AdminProductController::class, 'update'])->name('super-admin.products.update');
+Route::delete('super-admin/products/{id}', [AdminProductController::class, 'destroy'])->name('super-admin.products.destroy');
+Route::get('super-admin/get-subcategories', [AdminProductController::class, 'getSubCategories'])->name('super-admin.products.get-subcategories');


### PR DESCRIPTION
## Summary
- add Product model and migration with SEO and post date fields
- implement Admin ProductController with AJAX CRUD and dynamic sub-category lookup
- build product create/edit/list views with client-side validation and add menu & routes

## Testing
- `php -l app/Models/Product.php`
- `php -l app/Http/Controllers/Admin/ProductController.php`
- `php -l database/migrations/2025_08_04_000000_create_product_table.php`
- `./vendor/bin/phpunit --testdox` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_688f3637aeb083278b4322eedd5f02d0