### PR TITLE
Add On Page SEO CRUD module

### DIFF
--- a/app/Http/Controllers/Admin/OnPageSeoController.php
+++ b/app/Http/Controllers/Admin/OnPageSeoController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\OnPageSeo;
+use Illuminate\Http\Request;
+
+class OnPageSeoController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $perPage = $request->get('per_page', 10);
+        $seos = OnPageSeo::orderByDesc('id')->paginate($perPage);
+        return view('ursbid-admin.on_page_seo.list', compact('seos', 'perPage'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('ursbid-admin.on_page_seo.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'page_url' => 'required|string|max:255|unique:on_page_seo,page_url',
+            'page_name' => 'required|string|max:255',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        OnPageSeo::create($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'On Page SEO created successfully.',
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit($id)
+    {
+        $seo = OnPageSeo::findOrFail($id);
+        return view('ursbid-admin.on_page_seo.edit', compact('seo'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, $id)
+    {
+        $seo = OnPageSeo::findOrFail($id);
+
+        $validated = $request->validate([
+            'page_url' => 'required|string|max:255|unique:on_page_seo,page_url,' . $seo->id,
+            'page_name' => 'required|string|max:255',
+            'meta_title' => 'nullable|string|max:255',
+            'meta_keywords' => 'nullable|string|max:255',
+            'meta_description' => 'nullable|string',
+        ]);
+
+        $seo->update($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'On Page SEO updated successfully.',
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy($id)
+    {
+        $seo = OnPageSeo::findOrFail($id);
+        $seo->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'On Page SEO deleted successfully.',
+        ]);
+    }
+}
+

--- a/app/Models/OnPageSeo.php
+++ b/app/Models/OnPageSeo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class OnPageSeo extends Model
+{
+    protected $table = 'on_page_seo';
+
+    protected $fillable = [
+        'page_url',
+        'page_name',
+        'meta_title',
+        'meta_keywords',
+        'meta_description',
+    ];
+}
+

--- a/database/migrations/2025_08_05_000000_create_on_page_seo_table.php
+++ b/database/migrations/2025_08_05_000000_create_on_page_seo_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('on_page_seo', function (Blueprint $table) {
+            $table->id();
+            $table->string('page_url');
+            $table->string('page_name');
+            $table->string('meta_title')->nullable();
+            $table->string('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('on_page_seo');
+    }
+};
+

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -97,6 +97,25 @@
                      </ul>
                 </div>
            </li>
+
+            <li class="nav-item">
+                <a class="nav-link menu-arrow {{ request()->is('super-admin/on-page-seo*') ? 'active' : '' }}" href="#sidebarSeo" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('super-admin/on-page-seo*') ? 'true' : 'false' }}" aria-controls="sidebarSeo">
+                    <span class="nav-icon">
+                        <i class="ri-search-eye-line"></i>
+                    </span>
+                    <span class="nav-text">On Page SEO</span>
+                </a>
+                <div class="collapse {{ request()->is('super-admin/on-page-seo*') ? 'show' : '' }}" id="sidebarSeo">
+                    <ul class="nav sub-navbar-nav">
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/on-page-seo/create') ? 'active' : '' }}" href="{{ route('super-admin.on-page-seo.create') }}">Create</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/on-page-seo') ? 'active' : '' }}" href="{{ route('super-admin.on-page-seo.index') }}">List</a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
             
             <li class="nav-item">
                 <a class="nav-link menu-arrow" href="#sidebarProperty" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarProperty">

--- a/resources/views/ursbid-admin/on_page_seo/create.blade.php
+++ b/resources/views/ursbid-admin/on_page_seo/create.blade.php
@@ -1,0 +1,96 @@
+@extends('ursbid-admin.layouts.app')
+@section('title','Add On Page SEO')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="seoForm">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Page URL<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="page_url" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Page Name<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="page_name" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3"></textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#seoForm').validate({
+        rules:{
+            page_url:{required:true,url:true},
+            page_name:{required:true}
+        },
+        submitHandler:function(form){
+            $('#saveBtn').attr('disabled',true).text('Saving...');
+            $.ajax({
+                url: "{{ route('super-admin.on-page-seo.store') }}",
+                type:'POST',
+                data: $(form).serialize(),
+                success:function(res){
+                    toastr.success(res.message);
+                    form.reset();
+                },
+                error:function(xhr){
+                    let err = 'Error saving data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err,'Error');
+                },
+                complete:function(){
+                    $('#saveBtn').attr('disabled',false).text('Save');
+                }
+            });
+        }
+    });
+});
+</script>
+@endpush
+@endsection
+

--- a/resources/views/ursbid-admin/on_page_seo/edit.blade.php
+++ b/resources/views/ursbid-admin/on_page_seo/edit.blade.php
@@ -1,0 +1,95 @@
+@extends('ursbid-admin.layouts.app')
+@section('title','Edit On Page SEO')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="seoForm">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Page URL<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="page_url" class="form-control" value="{{ $seo->page_url }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Page Name<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="page_name" class="form-control" value="{{ $seo->page_name }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Title</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_title" class="form-control" value="{{ $seo->meta_title }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Keywords</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="meta_keywords" class="form-control" value="{{ $seo->meta_keywords }}">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Meta Description</label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="meta_description" class="form-control" rows="3">{{ $seo->meta_description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Update</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#seoForm').validate({
+        rules:{
+            page_url:{required:true,url:true},
+            page_name:{required:true}
+        },
+        submitHandler:function(form){
+            $('#saveBtn').attr('disabled',true).text('Saving...');
+            $.ajax({
+                url: "{{ route('super-admin.on-page-seo.update',$seo->id) }}",
+                type:'POST',
+                data: $(form).serialize(),
+                success:function(res){
+                    toastr.success(res.message);
+                },
+                error:function(xhr){
+                    let err = 'Error updating data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err,'Error');
+                },
+                complete:function(){
+                    $('#saveBtn').attr('disabled',false).text('Update');
+                }
+            });
+        }
+    });
+});
+</script>
+@endpush
+@endsection
+

--- a/resources/views/ursbid-admin/on_page_seo/list.blade.php
+++ b/resources/views/ursbid-admin/on_page_seo/list.blade.php
@@ -1,0 +1,79 @@
+@extends('ursbid-admin.layouts.app')
+@section('title','On Page SEO')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-xl-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <div>
+                        <h4 class="card-title mb-0">On Page SEO List</h4>
+                    </div>
+                    <a href="{{ route('super-admin.on-page-seo.create') }}" class="btn btn-sm btn-primary">Add On Page SEO</a>
+                </div>
+                <div class="table-responsive">
+                    <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>Page URL</th>
+                                <th>Page Name</th>
+                                <th>Meta Title</th>
+                                <th>Created At</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($seos as $seo)
+                            <tr id="row-{{ $seo->id }}">
+                                <td>{{ $seo->page_url }}</td>
+                                <td>{{ $seo->page_name }}</td>
+                                <td>{{ $seo->meta_title }}</td>
+                                <td>{{ $seo->created_at ? \Carbon\Carbon::parse($seo->created_at)->format('d-m-Y') : '' }}</td>
+                                <td>
+                                    <div class="d-flex gap-2">
+                                        <a href="{{ route('super-admin.on-page-seo.edit',$seo->id) }}" class="btn btn-soft-primary btn-sm">
+                                            <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </a>
+                                        <button type="button" data-id="{{ $seo->id }}" data-url="{{ route('super-admin.on-page-seo.destroy',$seo->id) }}" class="btn btn-soft-danger btn-sm deleteBtn">
+                                            <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                            @empty
+                            <tr>
+                                <td colspan="5" class="text-center">No records found.</td>
+                            </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                <x-paginationwithlength :paginator="$seos" />
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+@push('scripts')
+<script>
+$(function(){
+    $('.deleteBtn').on('click',function(){
+        if(!confirm('Are you sure want to delete?')) return;
+        let id = $(this).data('id');
+        let url = $(this).data('url');
+        $.ajax({
+            url:url,
+            type:'DELETE',
+            data:{ _token:'{{ csrf_token() }}' },
+            success:function(res){
+                toastr.success(res.message);
+                $('#row-'+id).remove();
+            },
+            error:function(){
+                toastr.error('Unable to delete record');
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -356,6 +356,7 @@ use App\Http\Controllers\Admin\CategoryController As AdminCategoryController;
 use App\Http\Controllers\Admin\SubCategoryController;
 use App\Http\Controllers\Admin\BlogController as AdminBlogController;
 use App\Http\Controllers\Admin\ProductController as AdminProductController;
+use App\Http\Controllers\Admin\OnPageSeoController;
 
 
 
@@ -391,6 +392,13 @@ Route::post('super-admin/blogs', [AdminBlogController::class, 'store'])->name('s
 Route::get('super-admin/blogs/{id}/edit', [AdminBlogController::class, 'edit'])->name('super-admin.blogs.edit');
 Route::post('super-admin/blogs/{id}', [AdminBlogController::class, 'update'])->name('super-admin.blogs.update');
 Route::delete('super-admin/blogs/{id}', [AdminBlogController::class, 'destroy'])->name('super-admin.blogs.destroy');
+
+Route::get('super-admin/on-page-seo', [OnPageSeoController::class, 'index'])->name('super-admin.on-page-seo.index');
+Route::get('super-admin/on-page-seo/create', [OnPageSeoController::class, 'create'])->name('super-admin.on-page-seo.create');
+Route::post('super-admin/on-page-seo', [OnPageSeoController::class, 'store'])->name('super-admin.on-page-seo.store');
+Route::get('super-admin/on-page-seo/{id}/edit', [OnPageSeoController::class, 'edit'])->name('super-admin.on-page-seo.edit');
+Route::post('super-admin/on-page-seo/{id}', [OnPageSeoController::class, 'update'])->name('super-admin.on-page-seo.update');
+Route::delete('super-admin/on-page-seo/{id}', [OnPageSeoController::class, 'destroy'])->name('super-admin.on-page-seo.destroy');
 
 Route::get('super-admin/products', [AdminProductController::class, 'index'])->name('super-admin.products.index');
 Route::get('super-admin/products/create', [AdminProductController::class, 'create'])->name('super-admin.products.create');


### PR DESCRIPTION
## Summary
- add migration, model, controller, routes and views for On Page SEO CRUD
- hook On Page SEO create/list into admin sidebar with AJAX validation

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/ursbid-work/vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3, php 8.4.11 does not satisfy requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6890e2b338788327b9ccaf4036188308