### PR TITLE
Add testimonial CRUD module to admin panel

### DIFF
--- a/app/Http/Controllers/Admin/TestimonialController.php
+++ b/app/Http/Controllers/Admin/TestimonialController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Testimonial;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class TestimonialController extends Controller
+{
+    public function index()
+    {
+        $testimonials = Testimonial::orderByDesc('id')->paginate(10);
+        return view('ursbid-admin.testimonial.list', compact('testimonials'));
+    }
+
+    public function create()
+    {
+        return view('ursbid-admin.testimonial.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'position' => 'required|string|max:255',
+            'description' => 'required|string',
+            'status' => 'required|in:1,2',
+        ]);
+
+        $validated['slug'] = Str::slug($validated['title']);
+
+        Testimonial::create($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Testimonial created successfully.',
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $testimonial = Testimonial::findOrFail($id);
+        return view('ursbid-admin.testimonial.edit', compact('testimonial'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $testimonial = Testimonial::findOrFail($id);
+
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'position' => 'required|string|max:255',
+            'description' => 'required|string',
+            'status' => 'required|in:1,2',
+        ]);
+
+        $validated['slug'] = Str::slug($validated['title']);
+
+        $testimonial->update($validated);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Testimonial updated successfully.',
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $testimonial = Testimonial::findOrFail($id);
+        $testimonial->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Testimonial deleted successfully.',
+        ]);
+    }
+}
+

--- a/app/Models/Testimonial.php
+++ b/app/Models/Testimonial.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Testimonial extends Model
+{
+    use HasFactory;
+
+    protected $table = 'testimonial';
+
+    protected $fillable = [
+        'title',
+        'position',
+        'description',
+        'slug',
+        'status',
+    ];
+}
+

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -125,6 +125,15 @@
                     <span class="nav-text">Youtube Links</span>
                 </a>
             </li>
+
+            <li class="nav-item">
+                <a class="nav-link {{ request()->is('super-admin/testimonials*') ? 'active' : '' }}" href="{{ route('super-admin.testimonials.index') }}">
+                    <span class="nav-icon">
+                        <i class="ri-chat-1-line"></i>
+                    </span>
+                    <span class="nav-text">Testimonials</span>
+                </a>
+            </li>
             
             <li class="nav-item">
                 <a class="nav-link menu-arrow" href="#sidebarProperty" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarProperty">

--- a/resources/views/ursbid-admin/testimonial/create.blade.php
+++ b/resources/views/ursbid-admin/testimonial/create.blade.php
@@ -1,0 +1,92 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add Testimonial')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="testimonialForm">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Position<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="position" class="form-control" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Description<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="description" class="form-control" rows="4" required></textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1">Active</option>
+                                    <option value="2">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#testimonialForm').validate({
+        rules:{
+            title:{required:true},
+            position:{required:true},
+            description:{required:true}
+        },
+        submitHandler:function(form){
+            $('#saveBtn').prop('disabled',true).text('Saving...');
+            $.ajax({
+                url: "{{ route('super-admin.testimonials.store') }}",
+                type: 'POST',
+                data: $(form).serialize(),
+                success: function(res){
+                    toastr.success(res.message);
+                    form.reset();
+                    $('#saveBtn').prop('disabled',false).text('Save');
+                },
+                error: function(xhr){
+                    let err = 'Error saving data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').prop('disabled',false).text('Save');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/testimonial/edit.blade.php
+++ b/resources/views/ursbid-admin/testimonial/edit.blade.php
@@ -1,0 +1,91 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Testimonial')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="testimonialForm">
+                        @csrf
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="title" class="form-control" value="{{ $testimonial->title }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Position<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="position" class="form-control" value="{{ $testimonial->position }}" required>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Description<span class="text-danger">*</span></label>
+                            </div>
+                            <div class="col-md-8">
+                                <textarea name="description" class="form-control" rows="4" required>{{ $testimonial->description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1" {{ $testimonial->status == 1 ? 'selected' : '' }}>Active</option>
+                                    <option value="2" {{ $testimonial->status == 2 ? 'selected' : '' }}>Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="text-end">
+                            <button type="submit" id="saveBtn" class="btn btn-primary">Update</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#testimonialForm').validate({
+        rules:{
+            title:{required:true},
+            position:{required:true},
+            description:{required:true}
+        },
+        submitHandler:function(form){
+            $('#saveBtn').prop('disabled',true).text('Updating...');
+            $.ajax({
+                url: "{{ route('super-admin.testimonials.update', $testimonial->id) }}",
+                type: 'POST',
+                data: $(form).serialize(),
+                success: function(res){
+                    toastr.success(res.message);
+                    $('#saveBtn').prop('disabled',false).text('Update');
+                },
+                error: function(xhr){
+                    let err = 'Error updating data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').prop('disabled',false).text('Update');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/testimonial/list.blade.php
+++ b/resources/views/ursbid-admin/testimonial/list.blade.php
@@ -1,0 +1,136 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Testimonials')
+@section('content')
+<div class="container-fluid">
+    <!-- Page Title -->
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Testimonials</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="javascript:void(0);">Dashboard</a></li>
+                    <li class="breadcrumb-item active">Testimonials</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+    <!-- End Page Title -->
+
+    <div class="row">
+        <div class="col-xl-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <div>
+                        <h4 class="card-title mb-0">All Testimonials</h4>
+                    </div>
+                    <a href="{{ route('super-admin.testimonials.create') }}" class="btn btn-sm btn-primary">Add Testimonial</a>
+                </div>
+                <div class="table-responsive">
+                    <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>Title</th>
+                                <th>Position</th>
+                                <th>Status</th>
+                                <th>Created At</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($testimonials as $item)
+                            <tr id="row-{{ $item->id }}">
+                                <td>{{ $item->title }}</td>
+                                <td>{{ $item->position }}</td>
+                                <td>
+                                    @if($item->status == 1)
+                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
+                                    @else
+                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
+                                    @endif
+                                </td>
+                                <td>{{ $item->created_at ? $item->created_at->format('d-m-Y') : '' }}</td>
+                                <td>
+                                    <div class="d-flex gap-2">
+                                        <a href="{{ route('super-admin.testimonials.edit', $item->id) }}" class="btn btn-soft-primary btn-sm">
+                                            <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </a>
+                                        <button type="button" data-id="{{ $item->id }}" data-url="{{ route('super-admin.testimonials.destroy', $item->id) }}" class="btn btn-soft-danger btn-sm deleteBtn">
+                                            <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                            @empty
+                            <tr>
+                                <td colspan="5" class="text-center">No testimonials found.</td>
+                            </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                <x-paginationwithlength :paginator="$testimonials" />
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content border-0 shadow-lg">
+      <div class="modal-header bg-danger text-white rounded-top">
+        <h5 class="modal-title" id="deleteConfirmLabel">
+            <i class="ri-error-warning-line me-2"></i> Confirm Deletion
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <div class="mb-3">
+          <i class="ri-alert-line text-danger" style="font-size: 40px;"></i>
+        </div>
+        <p class="mb-1 fs-5 fw-semibold">Are you sure you want to delete this item?</p>
+        <p class="text-muted">This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer justify-content-center border-0">
+        <button type="button" class="btn btn-light px-4" data-bs-dismiss="modal">
+            <i class="ri-close-line me-1"></i> Cancel
+        </button>
+        <button type="button" class="btn btn-danger px-4" id="confirmDeleteBtn">
+            <i class="ri-delete-bin-line me-1"></i> Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+let deleteId = null;
+let deleteUrl = null;
+$(function(){
+    $('.deleteBtn').on('click', function(){
+        deleteId = $(this).data('id');
+        deleteUrl = $(this).data('url');
+        $('#deleteConfirmModal').modal('show');
+    });
+
+    $('#confirmDeleteBtn').on('click', function(){
+        $.ajax({
+            url: deleteUrl,
+            type: 'DELETE',
+            data: { _token: '{{ csrf_token() }}' },
+            success: function(res){
+                $('#deleteConfirmModal').modal('hide');
+                toastr.success(res.message);
+                $('#row-'+deleteId).remove();
+            },
+            error: function(){
+                $('#deleteConfirmModal').modal('hide');
+                toastr.error('Unable to delete record');
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -358,6 +358,7 @@ use App\Http\Controllers\Admin\BlogController as AdminBlogController;
 use App\Http\Controllers\Admin\ProductController as AdminProductController;
 use App\Http\Controllers\Admin\OnPageSeoController;
 use App\Http\Controllers\Admin\YoutubeLinkController;
+use App\Http\Controllers\Admin\TestimonialController as AdminTestimonialController;
 
 
 
@@ -407,6 +408,13 @@ Route::post('super-admin/youtube-links', [YoutubeLinkController::class, 'store']
 Route::get('super-admin/youtube-links/{id}/edit', [YoutubeLinkController::class, 'edit'])->name('super-admin.youtube-links.edit');
 Route::post('super-admin/youtube-links/{id}', [YoutubeLinkController::class, 'update'])->name('super-admin.youtube-links.update');
 Route::delete('super-admin/youtube-links/{id}', [YoutubeLinkController::class, 'destroy'])->name('super-admin.youtube-links.destroy');
+
+Route::get('super-admin/testimonials', [AdminTestimonialController::class, 'index'])->name('super-admin.testimonials.index');
+Route::get('super-admin/testimonials/create', [AdminTestimonialController::class, 'create'])->name('super-admin.testimonials.create');
+Route::post('super-admin/testimonials', [AdminTestimonialController::class, 'store'])->name('super-admin.testimonials.store');
+Route::get('super-admin/testimonials/{id}/edit', [AdminTestimonialController::class, 'edit'])->name('super-admin.testimonials.edit');
+Route::post('super-admin/testimonials/{id}', [AdminTestimonialController::class, 'update'])->name('super-admin.testimonials.update');
+Route::delete('super-admin/testimonials/{id}', [AdminTestimonialController::class, 'destroy'])->name('super-admin.testimonials.destroy');
 
 Route::get('super-admin/products', [AdminProductController::class, 'index'])->name('super-admin.products.index');
 Route::get('super-admin/products/create', [AdminProductController::class, 'create'])->name('super-admin.products.create');


### PR DESCRIPTION
## Summary
- add Eloquent `Testimonial` model
- implement admin testimonial controller with AJAX CRUD
- create testimonial management views and menu entry
- register testimonial routes

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6890f3b9480c83279b8c2773684f8637