### PR TITLE
Apply product-style pagination to unit list

### DIFF
--- a/resources/views/ursbid-admin/unit/list.blade.php
+++ b/resources/views/ursbid-admin/unit/list.blade.php
@@ -2,6 +2,53 @@
 @section('title', 'Units')
 
 @section('content')
+<style>
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 20px;
+}
+
+.pagination {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    gap: 5px;
+}
+
+.page-item {
+    margin: 0;
+}
+
+.page-link {
+    display: inline-block;
+    padding: 5px 10px;
+    color: #333;
+    text-decoration: none;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background-color: #fff;
+}
+
+.page-item.active .page-link {
+    background-color: #614ce1;
+    color: #fff;
+    border-color: #614ce1;
+}
+
+.page-item.disabled .page-link {
+    color: #6c757d;
+    pointer-events: none;
+    background-color: #fff;
+    border-color: #ddd;
+}
+
+.page-link:hover {
+    background-color: #f8f9fa;
+    color: #0056b3;
+}
+</style>
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
@@ -16,7 +63,7 @@
     </div>
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -56,7 +103,7 @@
                                         <a href="{{ route('super-admin.units.edit', $unit->id) }}" class="btn btn-soft-primary btn-sm">
                                             <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
                                         </a>
-                                        <button type="button" data-id="{{ $unit->id }}" class="btn btn-soft-danger btn-sm deleteBtn">
+                                        <button type="button" data-id="{{ $unit->id }}" data-url="{{ route('super-admin.units.destroy', $unit->id) }}" class="btn btn-soft-danger btn-sm deleteBtn">
                                             <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
                                         </button>
                                     </div>
@@ -70,10 +117,8 @@
                         </tbody>
                     </table>
                 </div>
+                <x-paginationwithlength :paginator="$units" />
 
-                <div class="card-footer">
-                    {{ $units->links() }}
-                </div>
             </div>
         </div>
     </div>
@@ -85,9 +130,10 @@
 $(function(){
     $('.deleteBtn').on('click', function(){
         if(!confirm('Are you sure want to delete?')) return;
-        var id = $(this).data('id');
+        let id = $(this).data('id');
+        let url = $(this).data('url');
         $.ajax({
-            url: '/super-admin/units/'+id,
+            url: url,
             type: 'DELETE',
             data: { _token: '{{ csrf_token() }}' },
             success: function(res){


### PR DESCRIPTION
## Summary
- style unit list pagination to match product pages
- switch unit listing to custom pagination component
- route-based AJAX delete for units

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: nette/schema requires php 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_6890ff8294048327a20a2544175c9dc2