### PR TITLE
Add serial numbers to units list

### DIFF
--- a/resources/views/ursbid-admin/unit/list.blade.php
+++ b/resources/views/ursbid-admin/unit/list.blade.php
@@ -76,6 +76,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Category</th>
                                 <th>Sub Category</th>
                                 <th>Unit Title</th>
@@ -87,6 +88,7 @@
                         <tbody>
                             @forelse($units as $unit)
                             <tr id="row-{{ $unit->id }}">
+                                <td>{{ $units->firstItem() + $loop->index }}</td>
                                 <td>{{ $unit->category_title }}</td>
                                 <td>{{ $unit->sub_title }}</td>
                                 <td>{{ $unit->title }}</td>
@@ -111,7 +113,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="6" class="text-center">No units found.</td>
+                                <td colspan="7" class="text-center">No units found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- show serial number column in super admin units list with pagination-aware numbering
- adjust empty-state column span

## Testing
- `composer install --ignore-platform-reqs`
- `vendor/bin/phpunit` (fails: Missing app key)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689101aac7ac8327adb8d78d602a3251