### PR TITLE
Add S.No to testimonials list

### DIFF
--- a/resources/views/ursbid-admin/testimonial/list.blade.php
+++ b/resources/views/ursbid-admin/testimonial/list.blade.php
@@ -17,7 +17,7 @@
     <!-- End Page Title -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -29,6 +29,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Title</th>
                                 <th>Position</th>
                                 <th>Status</th>
@@ -39,6 +40,7 @@
                         <tbody>
                             @forelse($testimonials as $item)
                             <tr id="row-{{ $item->id }}">
+                                <td>{{ $testimonials->firstItem() + $loop->index }}</td>
                                 <td>{{ $item->title }}</td>
                                 <td>{{ $item->position }}</td>
                                 <td>
@@ -62,7 +64,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="5" class="text-center">No testimonials found.</td>
+                                <td colspan="6" class="text-center">No testimonials found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- add serial number column to testimonials index and ensure pagination-aware numbering

## Testing
- `composer install` (fails: nette/schema v1.2.5 requires php 7.1 - 8.3)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689244124fc08327bf3f3cf35412c8d3