### PR TITLE
Fix product brands list view missing layout

### DIFF
--- a/resources/views/ursbid-admin/product_brands/list.blade.php
+++ b/resources/views/ursbid-admin/product_brands/list.blade.php
@@ -1,3 +1,4 @@
+@extends('ursbid-admin.layouts.app')
 @section('title', 'Product Brands')
 
 @section('content')


### PR DESCRIPTION
## Summary
- Ensure product brand list view extends admin layout so page renders

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68924c77cf688327b4c7e39022e8c0ad