### PR TITLE
Add S.No column and date formatting to admin category lists

### DIFF
--- a/resources/views/ursbid-admin/category/list.blade.php
+++ b/resources/views/ursbid-admin/category/list.blade.php
@@ -19,7 +19,7 @@
     <!-- ========== Page Title End ========== -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -32,6 +32,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Category Title</th>
                                 <th>Post Date</th>
                                 <th>Status</th>
@@ -41,6 +42,7 @@
                         <tbody>
                             @forelse($categories as $category)
                             <tr id="row-{{ $category->id }}">
+                                <td>{{ $categories->firstItem() + $loop->index }}</td>
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
@@ -52,7 +54,7 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $category->post_date }}</td>
+                                <td>{{ $category->post_date ? \Carbon\Carbon::parse($category->post_date)->format('d-m-Y') : '' }}</td>
                                 <td>
                                     @if($category->status == '1')
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
@@ -73,7 +75,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="4" class="text-center">No categories found.</td>
+                                <td colspan="5" class="text-center">No categories found.</td>
                             </tr>
                             @endforelse
                         </tbody>

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -67,7 +67,7 @@
     <!-- ========== Page Title End ========== -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -80,6 +80,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Sub Category Title</th>
                                 <th>Category</th>
                                 <th>Post Date</th>
@@ -90,6 +91,7 @@
                         <tbody>
                             @forelse($subs as $sub)
                             <tr id="row-{{ $sub->id }}">
+                                <td>{{ $subs->firstItem() + $loop->index }}</td>
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
@@ -122,7 +124,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="5" class="text-center">No sub categories found.</td>
+                                <td colspan="6" class="text-center">No sub categories found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- show S.No in super-admin category and sub-category listings
- format post dates as `dd-mm-yyyy`
- unify list layout to use `row` > `col-md-12` > `card`

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: nette/schema requires php 7.1 - 8.3, current php 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_68924f02bd948327a1ce74dff995f548