### PR TITLE
Add serial numbers to admin lists

### DIFF
--- a/resources/views/admin/blog/list.blade.php
+++ b/resources/views/admin/blog/list.blade.php
@@ -6,7 +6,7 @@
 <div class="container-fluid">
     <div class="social-dash-wrap">
         <div class="row">
-            <div class="col-lg-12">
+            <div class="col-md-12">
 
                 <div class="breadcrumb-main">
                     <h4 class="text-capitalize breadcrumb-title">Blogs List</h4>
@@ -38,7 +38,7 @@
 
         </div>
         <div class="row">
-            <div class="col-lg-12 mb-30">
+            <div class="col-md-12 mb-30">
                 <div class="card">
                     <div class="col-md-12 mt-2">
                         <form class="row" method="get" action="">
@@ -91,7 +91,7 @@
                                     <thead>
                                         <tr class="userDatatable-header">
                                             <th>
-                                                <span class="projectDatatable-title">Sr no</span>
+                                                <span class="projectDatatable-title">S.No</span>
                                             </th>
                                             <th>
                                                 <span class="projectDatatable-title">Title</span>
@@ -116,15 +116,12 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @php
-                                        $i=1;
-                                        @endphp
                                         @foreach ($blogs as $blog)
 
                                         <tr>
                                             <td>
                                                 <div class="userDatatable-content text-center">
-                                                    {{ $i++ }}
+                                                    {{ $loop->iteration }}
                                                 </div>
                                             </td>
                                             <td>
@@ -134,7 +131,7 @@
                                             </td>
                                             <td>
                                                 <div class="userDatatable-content">
-                                                    {{ $blog->post_date }}
+                                                    {{ \Carbon\Carbon::parse($blog->post_date)->format('d-m-Y') }}
                                                 </div>
                                             </td>
                                             <td>

--- a/resources/views/admin/product/list.blade.php
+++ b/resources/views/admin/product/list.blade.php
@@ -6,7 +6,7 @@
 <div class="container-fluid">
     <div class="social-dash-wrap">
         <div class="row">
-            <div class="col-lg-12">
+            <div class="col-md-12">
 
                 <div class="breadcrumb-main">
                     <h4 class="text-capitalize breadcrumb-title">Product List</h4>
@@ -39,7 +39,7 @@
 
         </div>
         <div class="row">
-            <div class="col-lg-12 mb-30">
+            <div class="col-md-12 mb-30">
                 <div class="card">
                     <div class="col-md-12 mt-2">
                         <form class="row" method="get" action="">
@@ -92,7 +92,7 @@
                                     <thead>
                                         <tr class="userDatatable-header">
                                             <th>
-                                                <span class="projectDatatable-title">Sr no</span>
+                                                <span class="projectDatatable-title">S.No</span>
                                             </th>
                                             <th>
                                                 <span class="projectDatatable-title">Category</span>
@@ -125,15 +125,12 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @php
-                                        $i=1;
-                                        @endphp
                                         @foreach ($blogs as $blog)
 
                                         <tr>
                                             <td>
                                                 <div class="userDatatable-content text-center">
-                                                    {{ $i++ }}
+                                                    {{ $loop->iteration }}
                                                 </div>
                                             </td>
                                             <td>

--- a/resources/views/ursbid-admin/on_page_seo/list.blade.php
+++ b/resources/views/ursbid-admin/on_page_seo/list.blade.php
@@ -50,7 +50,7 @@
 </style>
 <div class="container-fluid">
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -62,6 +62,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Page URL</th>
                                 <th>Page Name</th>
                                 <th>Meta Title</th>
@@ -72,6 +73,7 @@
                         <tbody>
                             @forelse($seos as $seo)
                             <tr id="row-{{ $seo->id }}">
+                                <td>{{ $loop->iteration }}</td>
                                 <td>{{ $seo->page_url }}</td>
                                 <td>{{ $seo->page_name }}</td>
                                 <td>{{ $seo->meta_title }}</td>
@@ -89,7 +91,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="5" class="text-center">No records found.</td>
+                                <td colspan="6" class="text-center">No records found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- Replace manual counters with Blade loop iteration for product and blog listings
- Show blog dates in `dd-mm-yyyy` format
- Add S.No column to On Page SEO list

## Testing
- `composer install` *(fails: your php version (8.4.11) does not satisfy package requirements)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689251e3bb248327a3ec7506b97c49b2