### PR TITLE
feat: add advertisement management

### DIFF
--- a/app/Http/Controllers/Admin/AdvertisementController.php
+++ b/app/Http/Controllers/Admin/AdvertisementController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Advertisement;
+use App\Models\Category;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class AdvertisementController extends Controller
+{
+    public function index()
+    {
+        $advertisements = Advertisement::leftJoin('category', 'advertisements.category_id', '=', 'category.id')
+            ->select('advertisements.*', 'category.title as category_title')
+            ->orderByDesc('advertisements.id')
+            ->paginate(10);
+
+        return view('ursbid-admin.advertisement.list', compact('advertisements'));
+    }
+
+    public function create()
+    {
+        $categories = Category::where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.advertisement.create', compact('categories'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'category_id' => 'required|integer',
+            'image' => 'required|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+
+        if ($request->hasFile('image')) {
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads/advertisements'), $filename);
+            $data['image'] = 'uploads/advertisements/' . $filename;
+        }
+
+        $advertisement = Advertisement::create($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Advertisement created successfully.',
+            'data' => $advertisement,
+        ]);
+    }
+
+    public function edit($id)
+    {
+        $advertisement = Advertisement::findOrFail($id);
+        $categories = Category::where('status', 1)->orderBy('title')->get();
+        return view('ursbid-admin.advertisement.edit', compact('advertisement', 'categories'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $advertisement = Advertisement::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'category_id' => 'required|integer',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+
+        if ($request->hasFile('image')) {
+            if ($advertisement->image && file_exists(public_path($advertisement->image))) {
+                @unlink(public_path($advertisement->image));
+            }
+            $file = $request->file('image');
+            $filename = time() . '_' . $file->getClientOriginalName();
+            $file->move(public_path('uploads/advertisements'), $filename);
+            $data['image'] = 'uploads/advertisements/' . $filename;
+        }
+
+        $advertisement->update($data);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Advertisement updated successfully.',
+            'data' => $advertisement,
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $advertisement = Advertisement::findOrFail($id);
+        if ($advertisement->image && file_exists(public_path($advertisement->image))) {
+            @unlink(public_path($advertisement->image));
+        }
+        $advertisement->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Advertisement deleted successfully.',
+        ]);
+    }
+}

--- a/app/Models/Advertisement.php
+++ b/app/Models/Advertisement.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Advertisement extends Model
+{
+    protected $table = 'advertisements';
+
+    protected $fillable = [
+        'category_id',
+        'image',
+        'status',
+    ];
+}

--- a/database/migrations/2025_08_08_000000_create_advertisements_table.php
+++ b/database/migrations/2025_08_08_000000_create_advertisements_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('advertisements', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('category_id');
+            $table->string('image')->nullable();
+            $table->enum('status', ['1','2'])->default('1');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('advertisements');
+    }
+};

--- a/public/uploads/advertisements/.gitignore
+++ b/public/uploads/advertisements/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/resources/views/ursbid-admin/advertisement/create.blade.php
+++ b/resources/views/ursbid-admin/advertisement/create.blade.php
@@ -1,0 +1,110 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add Advertisement')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Add Advertisement</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="javascript:void(0);">Dashboard</a></li>
+                    <li class="breadcrumb-item active">Add Advertisement</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="adForm" enctype="multipart/form-data">
+                        @csrf
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="category_id" class="form-control">
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $category)
+                                        <option value="{{ $category->id }}">{{ $category->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control">
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1">Active</option>
+                                    <option value="2">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12 text-end">
+                                <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#adForm').validate({
+        rules:{
+            category_id:{required:true},
+            image:{required:true},
+            status:{required:true}
+        },
+        submitHandler:function(form){
+            var formData = new FormData(form);
+            $('#saveBtn').prop('disabled',true).text('Saving...');
+            $.ajax({
+                url: '{{ route('super-admin.advertisements.store') }}',
+                type: 'POST',
+                data: formData,
+                contentType: false,
+                processData: false,
+                success: function(res){
+                    if(res.status === 'success'){
+                        toastr.success(res.message);
+                        window.location.href = '{{ route('super-admin.advertisements.index') }}';
+                    } else {
+                        toastr.error(res.message || 'An error occurred');
+                        $('#saveBtn').prop('disabled',false).text('Save');
+                    }
+                },
+                error: function(xhr){
+                    let err = 'An error occurred';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join('<br>')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').prop('disabled',false).text('Save');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/advertisement/edit.blade.php
+++ b/resources/views/ursbid-admin/advertisement/edit.blade.php
@@ -1,0 +1,113 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Advertisement')
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Edit Advertisement</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="javascript:void(0);">Dashboard</a></li>
+                    <li class="breadcrumb-item active">Edit Advertisement</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="adForm" enctype="multipart/form-data">
+                        @csrf
+                        @method('PUT')
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Category</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="category_id" class="form-control">
+                                    <option value="">Select Category</option>
+                                    @foreach($categories as $category)
+                                        <option value="{{ $category->id }}" {{ $advertisement->category_id == $category->id ? 'selected' : '' }}>{{ $category->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Image</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="file" name="image" class="form-control">
+                                @if($advertisement->image)
+                                    <img src="{{ asset($advertisement->image) }}" alt="image" class="mt-2" width="80">
+                                @endif
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1" {{ $advertisement->status == '1' ? 'selected' : '' }}>Active</option>
+                                    <option value="2" {{ $advertisement->status == '2' ? 'selected' : '' }}>Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12 text-end">
+                                <button type="submit" id="saveBtn" class="btn btn-primary">Update</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
+<script>
+$(function(){
+    $('#adForm').validate({
+        rules:{
+            category_id:{required:true},
+            status:{required:true}
+        },
+        submitHandler:function(form){
+            var formData = new FormData(form);
+            $('#saveBtn').prop('disabled',true).text('Updating...');
+            $.ajax({
+                url: '{{ route('super-admin.advertisements.update', $advertisement->id) }}',
+                type: 'POST',
+                data: formData,
+                contentType: false,
+                processData: false,
+                success: function(res){
+                    if(res.status === 'success'){
+                        toastr.success(res.message);
+                        window.location.href = '{{ route('super-admin.advertisements.index') }}';
+                    } else {
+                        toastr.error(res.message || 'An error occurred');
+                        $('#saveBtn').prop('disabled',false).text('Update');
+                    }
+                },
+                error: function(xhr){
+                    let err = 'An error occurred';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e=>e.join('<br>')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveBtn').prop('disabled',false).text('Update');
+                }
+            });
+            return false;
+        }
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/advertisement/list.blade.php
+++ b/resources/views/ursbid-admin/advertisement/list.blade.php
@@ -1,0 +1,154 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Advertisements')
+
+@section('content')
+<style>
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 20px;
+}
+
+.pagination {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    gap: 5px;
+}
+
+.page-item {
+    margin: 0;
+}
+
+.page-link {
+    display: inline-block;
+    padding: 5px 10px;
+    color: #333;
+    text-decoration: none;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background-color: #fff;
+}
+
+.page-item.active .page-link {
+    background-color: #614ce1;
+    color: #fff;
+    border-color: #614ce1;
+}
+
+.page-item.disabled .page-link {
+    color: #6c757d;
+    pointer-events: none;
+    background-color: #fff;
+    border-color: #ddd;
+}
+
+.page-link:hover {
+    background-color: #f8f9fa;
+    color: #0056b3;
+}
+</style>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Advertisements</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="javascript:void(0);">Dashboard</a></li>
+                    <li class="breadcrumb-item active">Advertisements</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <div>
+                        <h4 class="card-title mb-0">All Advertisements List</h4>
+                    </div>
+                    <a href="{{ route('super-admin.advertisements.create') }}" class="btn btn-sm btn-primary">Add Advertisement</a>
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+                        <thead class="bg-light-subtle">
+                            <tr>
+                                <th>S.No</th>
+                                <th>Category</th>
+                                <th>Image</th>
+                                <th>Created Date</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse($advertisements as $ad)
+                            <tr id="row-{{ $ad->id }}">
+                                <td>{{ $advertisements->firstItem() + $loop->index }}</td>
+                                <td>{{ $ad->category_title }}</td>
+                                <td>
+                                    @if($ad->image)
+                                        <img src="{{ asset($ad->image) }}" alt="image" width="80">
+                                    @endif
+                                </td>
+                                <td>{{ \Carbon\Carbon::parse($ad->created_at)->format('d-m-Y') }}</td>
+                                <td>
+                                    @if($ad->status == '1')
+                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
+                                    @else
+                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    <div class="d-flex gap-2">
+                                        <a href="{{ route('super-admin.advertisements.edit', $ad->id) }}" class="btn btn-soft-primary btn-sm">
+                                            <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </a>
+                                        <button type="button" data-id="{{ $ad->id }}" data-url="{{ route('super-admin.advertisements.destroy', $ad->id) }}" class="btn btn-soft-danger btn-sm deleteBtn">
+                                            <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                            @empty
+                            <tr>
+                                <td colspan="6" class="text-center">No advertisements found.</td>
+                            </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                <x-paginationwithlength :paginator="$advertisements" />
+
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('.deleteBtn').on('click', function(){
+        if(!confirm('Are you sure want to delete?')) return;
+        let id = $(this).data('id');
+        let url = $(this).data('url');
+        $.ajax({
+            url: url,
+            type: 'DELETE',
+            data: { _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+                $('#row-'+id).remove();
+            },
+            error: function(){
+                toastr.error('Unable to delete record');
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -146,6 +146,25 @@
             </li>
 
             <li class="nav-item">
+                <a class="nav-link menu-arrow {{ request()->is('super-admin/advertisements*') ? 'active' : '' }}" href="#sidebarAdvertisements" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('super-admin/advertisements*') ? 'true' : 'false' }}" aria-controls="sidebarAdvertisements">
+                    <span class="nav-icon">
+                        <i class="ri-advertisement-line"></i>
+                    </span>
+                    <span class="nav-text"> Advertisements </span>
+                </a>
+                <div class="collapse {{ request()->is('super-admin/advertisements*') ? 'show' : '' }}" id="sidebarAdvertisements">
+                    <ul class="nav sub-navbar-nav">
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/advertisements/create') ? 'active' : '' }}" href="{{ route('super-admin.advertisements.create') }}">Add Advertisement</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/advertisements') ? 'active' : '' }}" href="{{ route('super-admin.advertisements.index') }}">Advertisement List</a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
                 <a class="nav-link menu-arrow {{ request()->is('super-admin/product-brands*') ? 'active' : '' }}" href="#sidebarProductBrands" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('super-admin/product-brands*') ? 'true' : 'false' }}" aria-controls="sidebarProductBrands">
                     <span class="nav-icon">
                         <i class="ri-price-tag-3-line"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -360,6 +360,7 @@ use App\Http\Controllers\Admin\OnPageSeoController;
 use App\Http\Controllers\Admin\YoutubeLinkController;
 use App\Http\Controllers\Admin\TestimonialController as AdminTestimonialController;
 use App\Http\Controllers\Admin\UnitController;
+use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Admin\ProductBrandController;
 
 
@@ -396,6 +397,13 @@ Route::post('super-admin/units', [UnitController::class, 'store'])->name('super-
 Route::get('super-admin/units/{id}/edit', [UnitController::class, 'edit'])->name('super-admin.units.edit');
 Route::put('super-admin/units/{id}', [UnitController::class, 'update'])->name('super-admin.units.update');
 Route::delete('super-admin/units/{id}', [UnitController::class, 'destroy'])->name('super-admin.units.destroy');
+
+Route::get('super-admin/advertisements', [AdvertisementController::class, 'index'])->name('super-admin.advertisements.index');
+Route::get('super-admin/advertisements/create', [AdvertisementController::class, 'create'])->name('super-admin.advertisements.create');
+Route::post('super-admin/advertisements', [AdvertisementController::class, 'store'])->name('super-admin.advertisements.store');
+Route::get('super-admin/advertisements/{id}/edit', [AdvertisementController::class, 'edit'])->name('super-admin.advertisements.edit');
+Route::put('super-admin/advertisements/{id}', [AdvertisementController::class, 'update'])->name('super-admin.advertisements.update');
+Route::delete('super-admin/advertisements/{id}', [AdvertisementController::class, 'destroy'])->name('super-admin.advertisements.destroy');
 
 Route::get('super-admin/product-brands', [ProductBrandController::class, 'index'])->name('super-admin.product-brands.index');
 Route::get('super-admin/product-brands/create', [ProductBrandController::class, 'create'])->name('super-admin.product-brands.create');


### PR DESCRIPTION
## Summary
- add advertisement CRUD controller with AJAX validation
- create advertisement views and sidebar links
- setup advertisement migration and model

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: your php version (8.4.11) does not satisfy dependency requirements)*

------
https://chatgpt.com/codex/tasks/task_e_689254682d30832796bc2ea2232f3162