### PR TITLE
Add serial numbers to product and blog lists

### DIFF
--- a/resources/views/ursbid-admin/blogs/list.blade.php
+++ b/resources/views/ursbid-admin/blogs/list.blade.php
@@ -73,7 +73,7 @@
     <!-- ========== Page Title End ========== -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -86,6 +86,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Blog Title</th>
                                 <th>Post Date</th>
                                 <th>Status</th>
@@ -95,6 +96,7 @@
                         <tbody>
                             @forelse($blogs as $blog)
                             <tr id="row-{{ $blog->id }}">
+                                <td>{{ ($blogs->currentPage() - 1) * $blogs->perPage() + $loop->iteration }}</td>
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
@@ -118,9 +120,9 @@
                                         <a href="{{ route('super-admin.blogs.edit', $blog->id) }}" class="btn btn-soft-primary btn-sm">
                                             <iconify-icon icon="solar:pen-2-broken" class="align-middle fs-18"></iconify-icon>
                                         </a>
-                                        <button type="button" 
-                                                data-id="{{ $blog->id }}" 
-                                                data-url="{{ route('super-admin.blogs.destroy', $blog->id) }}" 
+                                        <button type="button"
+                                                data-id="{{ $blog->id }}"
+                                                data-url="{{ route('super-admin.blogs.destroy', $blog->id) }}"
                                                 class="btn btn-soft-danger btn-sm deleteBtn">
                                             <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
                                         </button>
@@ -129,7 +131,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="4" class="text-center">No blogs found.</td>
+                                <td colspan="5" class="text-center">No blogs found.</td>
                             </tr>
                             @endforelse
                         </tbody>

--- a/resources/views/ursbid-admin/products/list.blade.php
+++ b/resources/views/ursbid-admin/products/list.blade.php
@@ -68,7 +68,7 @@
     <!-- ========== Page Title End ========== -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>
@@ -81,6 +81,7 @@
                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
                         <thead class="bg-light-subtle">
                             <tr>
+                                <th>S.No</th>
                                 <th>Product Title</th>
                                 <th>Category</th>
                                 <th>Sub Category</th>
@@ -92,6 +93,7 @@
                         <tbody>
                             @forelse($products as $product)
                             <tr id="row-{{ $product->id }}">
+                                <td>{{ ($products->currentPage() - 1) * $products->perPage() + $loop->iteration }}</td>
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
@@ -104,7 +106,7 @@
                                 </td>
                                 <td>{{ $product->category_title }}</td>
                                 <td>{{ $product->sub_title }}</td>
-                                <td></td>
+                                <td>{{ $product->post_date ? \Carbon\Carbon::parse($product->post_date)->format('d-m-Y') : '' }}</td>
                                 <td>
                                     @if($product->status == 1)
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
@@ -125,7 +127,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="6" class="text-center">No products found.</td>
+                                <td colspan="7" class="text-center">No products found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- show serial number for products and blogs in admin lists
- format post dates using dd-mm-yyyy and update layouts

## Testing
- `composer install` *(fails: nette/schema requires PHP 7.1 - 8.3, current PHP 8.4)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68934679a0588327a9cd22e7b5a87397