### PR TITLE
Add UserAccount model and migration

### DIFF
--- a/app/Models/UserAccount.php
+++ b/app/Models/UserAccount.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserAccount extends Model
+{
+    use HasFactory;
+
+    protected $table = 'user_accounts';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'password',
+        'user_type',
+        'gender',
+        'gst_no',
+        'otp',
+        'latitude',
+        'longitude',
+        'status',
+        'referral_code',
+        'referral_by',
+        'is_verified',
+        'product_and_services',
+        'parent_id',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    protected $casts = [
+        'latitude' => 'float',
+        'longitude' => 'float',
+    ];
+}

--- a/database/migrations/2025_08_09_000000_create_user_accounts_table.php
+++ b/database/migrations/2025_08_09_000000_create_user_accounts_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_accounts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name', 255);
+            $table->string('email', 255)->unique();
+            $table->string('phone', 20)->unique();
+            $table->string('password', 255);
+            $table->string('user_type', 50);
+            $table->string('gender', 20)->nullable();
+            $table->string('gst_no', 30)->nullable();
+            $table->string('otp', 10)->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->enum('status', ['1', '2'])->default('1')->comment('1->Active, 2->Inactive');
+            $table->string('referral_code', 20)->nullable();
+            $table->string('referral_by', 20)->nullable();
+            $table->enum('is_verified', ['1', '2'])->default('1')->comment('1->Verified, 2->Not Verified');
+            $table->text('product_and_services')->nullable();
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_accounts');
+    }
+};


### PR DESCRIPTION
## Summary
- add `UserAccount` Eloquent model with fillable fields and coordinate casting
- create migration for `user_accounts` table with contact, status, and tracking columns

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3; current php 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_68939844891c83278b496ca5e52f5f9f