### PR TITLE
Add account module with AJAX validation

### DIFF
--- a/app/Http/Controllers/UserAccountController.php
+++ b/app/Http/Controllers/UserAccountController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UserAccount;
+use Illuminate\Http\Request;
+
+class UserAccountController extends Controller
+{
+    public function index()
+    {
+        return view('admin.account.index');
+    }
+
+    public function list($type)
+    {
+        $accounts = UserAccount::where('user_type', $type)
+            ->select('id', 'name', 'email', 'phone', 'user_type', 'created_at')
+            ->orderBy('id', 'desc')
+            ->get()
+            ->map(function ($item) {
+                $item->created_at_formatted = $item->created_at ? $item->created_at->format('d-m-Y') : null;
+                return $item;
+            });
+        return response()->json($accounts);
+    }
+
+    public function show($id)
+    {
+        $account = UserAccount::findOrFail($id);
+        $account->created_at_formatted = $account->created_at ? $account->created_at->format('d-m-Y') : null;
+        return response()->json($account);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $account = UserAccount::findOrFail($id);
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|max:255|unique:user_accounts,email,' . $id,
+            'phone' => 'required|string|max:20|unique:user_accounts,phone,' . $id,
+        ]);
+        $account->update($validated);
+        return response()->json(['success' => true, 'user_type' => $account->user_type]);
+    }
+}
+

--- a/resources/views/admin/account/index.blade.php
+++ b/resources/views/admin/account/index.blade.php
@@ -1,0 +1,166 @@
+@extends('admin.layout')
+@section('title','Account Module')
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h6>Account Module</h6>
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <button class="btn btn-primary show-list" data-type="vendor">Vendor List</button>
+                    <button class="btn btn-primary show-list" data-type="buyer">Buyer List</button>
+                    <button class="btn btn-primary show-list" data-type="contractor">Contractor List</button>
+                    <button class="btn btn-primary show-list" data-type="client">Client List</button>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-bordered" id="accounts-table">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Name</th>
+                                <th>Email</th>
+                                <th>Phone</th>
+                                <th>Date</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="editModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit Account</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="edit-form">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <input type="text" name="name" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Email</label>
+                        <input type="email" name="email" class="form-control" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Phone</label>
+                        <input type="text" name="phone" class="form-control" required>
+                    </div>
+                    <div id="edit-errors" class="text-danger mb-2"></div>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="viewModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Account Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p><strong>Name:</strong> <span id="view-name"></span></p>
+                <p><strong>Email:</strong> <span id="view-email"></span></p>
+                <p><strong>Phone:</strong> <span id="view-phone"></span></p>
+                <p><strong>User Type:</strong> <span id="view-user-type"></span></p>
+                <p><strong>Date:</strong> <span id="view-date"></span></p>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('script')
+<script>
+$(function(){
+    $.ajaxSetup({
+        headers: {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')}
+    });
+
+    $('.show-list').on('click', function(){
+        var type = $(this).data('type');
+        $.get('/admin/accounts/list/' + type, function(data){
+            var tbody = $('#accounts-table tbody');
+            tbody.empty();
+            data.forEach(function(item){
+                tbody.append('<tr>'+
+                    '<td>'+item.id+'</td>'+
+                    '<td>'+item.name+'</td>'+
+                    '<td>'+item.email+'</td>'+
+                    '<td>'+item.phone+'</td>'+
+                    '<td>'+(item.created_at_formatted ? item.created_at_formatted : '')+'</td>'+
+                    '<td><button class="btn btn-sm btn-secondary edit-btn" data-id="'+item.id+'">Edit</button> '+
+                    '<button class="btn btn-sm btn-info view-btn" data-id="'+item.id+'">View</button></td>'+
+                    '</tr>');
+            });
+        });
+    });
+
+    $(document).on('click','.edit-btn',function(){
+        var id = $(this).data('id');
+        $.get('/admin/accounts/' + id, function(res){
+            $('#edit-form').data('id', id);
+            $('#edit-form [name=name]').val(res.name);
+            $('#edit-form [name=email]').val(res.email);
+            $('#edit-form [name=phone]').val(res.phone);
+            $('#edit-errors').html('');
+            $('#editModal').modal('show');
+        });
+    });
+
+    $('#edit-form').on('submit', function(e){
+        e.preventDefault();
+        var form = $(this);
+        if(!form[0].checkValidity()){
+            form[0].reportValidity();
+            return;
+        }
+        var id = form.data('id');
+        $.ajax({
+            url: '/admin/accounts/' + id,
+            type: 'POST',
+            data: form.serialize(),
+            success: function(res){
+                $('#editModal').modal('hide');
+                $('.show-list[data-type="'+res.user_type+'"]').click();
+            },
+            error: function(xhr){
+                if(xhr.responseJSON && xhr.responseJSON.errors){
+                    var html='';
+                    $.each(xhr.responseJSON.errors, function(k,v){
+                        html += v[0]+'<br>';
+                    });
+                    $('#edit-errors').html(html);
+                }
+            }
+        });
+    });
+
+    $(document).on('click','.view-btn',function(){
+        var id = $(this).data('id');
+        $.get('/admin/accounts/' + id, function(res){
+            $('#view-name').text(res.name);
+            $('#view-email').text(res.email);
+            $('#view-phone').text(res.phone);
+            $('#view-user-type').text(res.user_type);
+            $('#view-date').text(res.created_at_formatted ? res.created_at_formatted : '');
+            $('#viewModal').modal('show');
+        });
+    });
+});
+</script>
+@endsection
+

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -412,6 +412,12 @@
 
                         
                         
+                        <li>
+                            <a href="{{ url('admin/accounts') }}" class="">
+                                <span data-feather="users" class="nav-icon"></span>
+                                <span class="menu-text">Account Module</span>
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 use App\Http\Controllers\PasswordResetController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\EmailController;
+use App\Http\Controllers\UserAccountController;
 
 
 /*
@@ -307,6 +308,11 @@ Route::get('/admin/register/contractorlist', [App\Http\Controllers\CategoryContr
 Route::get('/admin/register/sellerlist', [App\Http\Controllers\CategoryController::class, 'sellerlist']);
 Route::get('/admin/seller/active/{any}', [App\Http\Controllers\CategoryController::class, 'selleractive'])->name('admin.seller.active');
 Route::get('/admin/seller/deactive/{any}', [App\Http\Controllers\CategoryController::class, 'sellerdeactive'])->name('admin.seller.deactive');
+
+Route::get('/admin/accounts', [UserAccountController::class, 'index']);
+Route::get('/admin/accounts/list/{type}', [UserAccountController::class, 'list']);
+Route::get('/admin/accounts/{id}', [UserAccountController::class, 'show']);
+Route::post('/admin/accounts/{id}', [UserAccountController::class, 'update']);
 
 // Unit
 Route::get('/admin/unit/add', [App\Http\Controllers\UnitController::class, 'index']);


### PR DESCRIPTION
## Summary
- add UserAccountController to serve account listings and updates with server-side validation
- create account module view with AJAX listing/editing and dd-mm-yyyy date formatting
- wire account module routes and sidebar link

## Testing
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68939c0f20408327bb495903fedecaad