### PR TITLE
Add account module for user account management

### DIFF
--- a/app/Http/Controllers/Admin/UserAccountController.php
+++ b/app/Http/Controllers/Admin/UserAccountController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserAccount;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class UserAccountController extends Controller
+{
+    protected array $types = [
+        'vendors' => ['user_type' => 'vendor', 'label' => 'Vendor'],
+        'buyers' => ['user_type' => 'buyer', 'label' => 'Buyer'],
+        'contractors' => ['user_type' => 'contractor', 'label' => 'Contractor'],
+        'clients' => ['user_type' => 'client', 'label' => 'Client'],
+    ];
+
+    protected function getTypeData(string $type): array
+    {
+        if (!isset($this->types[$type])) {
+            abort(404);
+        }
+
+        return $this->types[$type];
+    }
+
+    public function index(string $type)
+    {
+        $data = $this->getTypeData($type);
+
+        return view('ursbid-admin.user_accounts.index', [
+            'type' => $type,
+            'userType' => $data['label'],
+        ]);
+    }
+
+    public function list(string $type)
+    {
+        $data = $this->getTypeData($type);
+        $users = UserAccount::where('user_type', $data['user_type'])
+            ->orderByDesc('id')
+            ->get();
+
+        $html = view('ursbid-admin.user_accounts.partials.table', [
+            'users' => $users,
+            'type' => $type,
+        ])->render();
+
+        return response()->json([
+            'status' => 'success',
+            'html' => $html,
+        ]);
+    }
+
+    public function edit(string $type, int $id)
+    {
+        $data = $this->getTypeData($type);
+        $user = UserAccount::where('user_type', $data['user_type'])->findOrFail($id);
+
+        return view('ursbid-admin.user_accounts.edit', [
+            'user' => $user,
+            'type' => $type,
+            'userType' => $data['label'],
+        ]);
+    }
+
+    public function show(string $type, int $id)
+    {
+        $data = $this->getTypeData($type);
+        $user = UserAccount::where('user_type', $data['user_type'])->findOrFail($id);
+
+        return view('ursbid-admin.user_accounts.show', [
+            'user' => $user,
+            'type' => $type,
+            'userType' => $data['label'],
+        ]);
+    }
+
+    public function update(Request $request, string $type, int $id)
+    {
+        $data = $this->getTypeData($type);
+        $user = UserAccount::where('user_type', $data['user_type'])->findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:user_accounts,email,' . $user->id,
+            'phone' => 'required|string|max:20|unique:user_accounts,phone,' . $user->id,
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user->update($validator->validated());
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Account updated successfully.',
+        ]);
+    }
+}
+

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -118,6 +118,31 @@
             </li>
 
             <li class="nav-item">
+                <a class="nav-link menu-arrow {{ request()->is('super-admin/accounts*') ? 'active' : '' }}" href="#sidebarAccounts" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('super-admin/accounts*') ? 'true' : 'false' }}" aria-controls="sidebarAccounts">
+                    <span class="nav-icon">
+                        <i class="ri-user-3-line"></i>
+                    </span>
+                    <span class="nav-text">Account Module</span>
+                </a>
+                <div class="collapse {{ request()->is('super-admin/accounts*') ? 'show' : '' }}" id="sidebarAccounts">
+                    <ul class="nav sub-navbar-nav">
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/accounts/vendors*') ? 'active' : '' }}" href="{{ route('super-admin.accounts.index', 'vendors') }}">Vendor List</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/accounts/buyers*') ? 'active' : '' }}" href="{{ route('super-admin.accounts.index', 'buyers') }}">Buyer List</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/accounts/contractors*') ? 'active' : '' }}" href="{{ route('super-admin.accounts.index', 'contractors') }}">Contractor List</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/accounts/clients*') ? 'active' : '' }}" href="{{ route('super-admin.accounts.index', 'clients') }}">Client List</a>
+                        </li>
+                    </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
                 <a class="nav-link {{ request()->is('super-admin/youtube-links*') ? 'active' : '' }}" href="{{ route('super-admin.youtube-links.index') }}">
                     <span class="nav-icon">
                         <i class="ri-youtube-line"></i>

--- a/resources/views/ursbid-admin/user_accounts/edit.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/edit.blade.php
@@ -1,0 +1,90 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit ' . $userType)
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Edit {{ $userType }}</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.accounts.index', $type) }}">{{ $userType }} List</a></li>
+                    <li class="breadcrumb-item active">Edit</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Edit {{ $userType }}</h4>
+                </div>
+                <form id="userForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" value="{{ $user->name }}" required>
+                            <div class="invalid-feedback" data-field="name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" value="{{ $user->email }}" required>
+                            <div class="invalid-feedback" data-field="email"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" value="{{ $user->phone }}" required>
+                            <div class="invalid-feedback" data-field="phone"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1" {{ $user->status == '1' ? 'selected' : '' }}>Active</option>
+                                <option value="2" {{ $user->status == '2' ? 'selected' : '' }}>Inactive</option>
+                            </select>
+                            <div class="invalid-feedback" data-field="status"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#userForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        $.ajax({
+            url: '{{ route('super-admin.accounts.update', [$type, $user->id]) }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for (let field in errors) {
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Update failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_accounts/index.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/index.blade.php
@@ -1,0 +1,46 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', $userType . ' List')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">{{ $userType }} List</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item active">{{ $userType }} List</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <h4 class="card-title mb-0">{{ $userType }} Accounts</h4>
+                    <button id="showListBtn" class="btn btn-sm btn-primary">Show List</button>
+                </div>
+                <div id="listContainer" class="table-responsive"></div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#showListBtn').on('click', function(){
+        $.get('{{ route('super-admin.accounts.list', $type) }}', function(res){
+            if(res.status === 'success'){
+                $('#listContainer').html(res.html);
+            }
+        }).fail(function(){
+            toastr.error('Unable to load list');
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_accounts/partials/table.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/partials/table.blade.php
@@ -1,0 +1,41 @@
+<table class="table align-middle text-nowrap table-hover table-centered mb-0">
+    <thead class="bg-light-subtle">
+        <tr>
+            <th>S.No</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Phone</th>
+            <th>Created Date</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($users as $user)
+            <tr>
+                <td>{{ $loop->iteration }}</td>
+                <td>{{ $user->name }}</td>
+                <td>{{ $user->email }}</td>
+                <td>{{ $user->phone }}</td>
+                <td>{{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}</td>
+                <td>
+                    @if($user->status == '1')
+                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
+                    @else
+                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
+                    @endif
+                </td>
+                <td>
+                    <div class="d-flex gap-2">
+                        <a href="{{ route('super-admin.accounts.edit', [$type, $user->id]) }}" class="btn btn-soft-primary btn-sm">Edit</a>
+                        <a href="{{ route('super-admin.accounts.show', [$type, $user->id]) }}" class="btn btn-soft-info btn-sm">View</a>
+                    </div>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="7" class="text-center">No records found.</td>
+            </tr>
+        @endforelse
+    </tbody>
+</table>

--- a/resources/views/ursbid-admin/user_accounts/show.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/show.blade.php
@@ -1,0 +1,36 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'View ' . $userType)
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">View {{ $userType }}</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.accounts.index', $type) }}">{{ $userType }} List</a></li>
+                    <li class="breadcrumb-item active">View</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Account Details</h4>
+                </div>
+                <div class="card-body">
+                    <div class="mb-2"><strong>Name:</strong> {{ $user->name }}</div>
+                    <div class="mb-2"><strong>Email:</strong> {{ $user->email }}</div>
+                    <div class="mb-2"><strong>Phone:</strong> {{ $user->phone }}</div>
+                    <div class="mb-2"><strong>Created Date:</strong> {{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}</div>
+                    <div class="mb-2"><strong>Status:</strong> {{ $user->status == '1' ? 'Active' : 'Inactive' }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -362,6 +362,7 @@ use App\Http\Controllers\Admin\TestimonialController as AdminTestimonialControll
 use App\Http\Controllers\Admin\UnitController;
 use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Admin\ProductBrandController;
+use App\Http\Controllers\Admin\UserAccountController;
 
 
 
@@ -447,6 +448,14 @@ Route::get('super-admin/products/{id}/edit', [AdminProductController::class, 'ed
 Route::post('super-admin/products/{id}', [AdminProductController::class, 'update'])->name('super-admin.products.update');
 Route::delete('super-admin/products/{id}', [AdminProductController::class, 'destroy'])->name('super-admin.products.destroy');
 Route::get('super-admin/get-subcategories', [AdminProductController::class, 'getSubCategories'])->name('super-admin.products.get-subcategories');
+
+Route::prefix('super-admin/accounts')->name('super-admin.accounts.')->group(function () {
+    Route::get('{type}', [UserAccountController::class, 'index'])->name('index');
+    Route::get('{type}/list', [UserAccountController::class, 'list'])->name('list');
+    Route::get('{type}/{id}/edit', [UserAccountController::class, 'edit'])->name('edit');
+    Route::get('{type}/{id}', [UserAccountController::class, 'show'])->name('show');
+    Route::put('{type}/{id}', [UserAccountController::class, 'update'])->name('update');
+});
 
 
 


### PR DESCRIPTION
## Summary
- add `UserAccountController` to manage vendor, buyer, contractor, and client accounts with AJAX-based listing and updates
- expose account management routes and sidebar links for each user type
- implement account list and edit views using card layout and dd-mm-yyyy date format

## Testing
- `composer install --ignore-platform-reqs`
- `php artisan key:generate`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68939ecc6eac8327879c3b273367473d