### PR TITLE
Add AJAX filtering and account CRUD

### DIFF
--- a/resources/views/ursbid-admin/user_accounts/create.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/create.blade.php
@@ -1,0 +1,90 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add ' . $userType)
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Add {{ $userType }}</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.accounts.index', $type) }}">{{ $userType }} List</a></li>
+                    <li class="breadcrumb-item active">Add</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Add {{ $userType }}</h4>
+                </div>
+                <form id="userForm">
+                    @csrf
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" required>
+                            <div class="invalid-feedback" data-field="name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" required>
+                            <div class="invalid-feedback" data-field="email"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" required>
+                            <div class="invalid-feedback" data-field="phone"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1">Active</option>
+                                <option value="2">Inactive</option>
+                            </select>
+                            <div class="invalid-feedback" data-field="status"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#userForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        $.ajax({
+            url: '{{ route('super-admin.accounts.store', $type) }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+                $('#userForm')[0].reset();
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for(let field in errors){
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Creation failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_accounts/index.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/index.blade.php
@@ -14,13 +14,53 @@
             </div>
         </div>
     </div>
+    <div class="row mb-3">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <form id="filterForm">
+                        <div class="row g-3">
+                            <div class="col-md-3">
+                                <label class="form-label">Name</label>
+                                <input type="text" name="name" class="form-control" placeholder="Name">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">Email</label>
+                                <input type="text" name="email" class="form-control" placeholder="Email">
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">Status</label>
+                                <select name="status" class="form-select">
+                                    <option value="">All</option>
+                                    <option value="1">Active</option>
+                                    <option value="2">Inactive</option>
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">From Date</label>
+                                <input type="text" name="from_date" class="form-control" placeholder="dd-mm-yyyy">
+                            </div>
+                            <div class="col-md-2">
+                                <label class="form-label">To Date</label>
+                                <input type="text" name="to_date" class="form-control" placeholder="dd-mm-yyyy">
+                            </div>
+                            <div class="col-12 text-end">
+                                <button type="submit" class="btn btn-primary">Filter</button>
+                                <button type="button" id="resetBtn" class="btn btn-secondary ms-2">Reset</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="row">
         <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <h4 class="card-title mb-0">{{ $userType }} Accounts</h4>
-                    <button id="showListBtn" class="btn btn-sm btn-primary">Show List</button>
+                    <a href="{{ route('super-admin.accounts.create', $type) }}" class="btn btn-sm btn-primary">Add {{ $userType }}</a>
                 </div>
                 <div id="listContainer" class="table-responsive"></div>
             </div>
@@ -32,15 +72,55 @@
 @push('scripts')
 <script>
 $(function(){
-    $('#showListBtn').on('click', function(){
-        $.get('{{ route('super-admin.accounts.list', $type) }}', function(res){
-            if(res.status === 'success'){
+    function loadList(){
+        $.ajax({
+            url: '{{ route('super-admin.accounts.list', $type) }}',
+            data: $('#filterForm').serialize(),
+            success: function(res){
                 $('#listContainer').html(res.html);
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    toastr.error('Please provide valid filter inputs.');
+                }else{
+                    toastr.error('Unable to load list');
+                }
             }
-        }).fail(function(){
-            toastr.error('Unable to load list');
         });
+    }
+
+    $('#filterForm').on('submit', function(e){
+        e.preventDefault();
+        const name = $('input[name="name"]').val();
+        const email = $('input[name="email"]').val();
+        const from = $('input[name="from_date"]').val();
+        const to = $('input[name="to_date"]').val();
+        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        if(name.length > 255){
+            toastr.error('Name may not be greater than 255 characters.');
+            return;
+        }
+        if(email.length > 255){
+            toastr.error('Email may not be greater than 255 characters.');
+            return;
+        }
+        if(from && !datePattern.test(from)){
+            toastr.error('From date must be in dd-mm-yyyy format.');
+            return;
+        }
+        if(to && !datePattern.test(to)){
+            toastr.error('To date must be in dd-mm-yyyy format.');
+            return;
+        }
+        loadList();
     });
+
+    $('#resetBtn').on('click', function(){
+        $('#filterForm')[0].reset();
+        loadList();
+    });
+
+    loadList();
 });
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -452,6 +452,8 @@ Route::get('super-admin/get-subcategories', [AdminProductController::class, 'get
 Route::prefix('super-admin/accounts')->name('super-admin.accounts.')->group(function () {
     Route::get('{type}', [UserAccountController::class, 'index'])->name('index');
     Route::get('{type}/list', [UserAccountController::class, 'list'])->name('list');
+    Route::get('{type}/create', [UserAccountController::class, 'create'])->name('create');
+    Route::post('{type}', [UserAccountController::class, 'store'])->name('store');
     Route::get('{type}/{id}/edit', [UserAccountController::class, 'edit'])->name('edit');
     Route::get('{type}/{id}', [UserAccountController::class, 'show'])->name('show');
     Route::put('{type}/{id}', [UserAccountController::class, 'update'])->name('update');


### PR DESCRIPTION
## Summary
- support creation of vendor, buyer, contractor, and client accounts through new controller methods and routes
- add filterable account list with client-side validation and async loading
- provide an AJAX-driven account creation form

## Testing
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3, but php 8.4.11 installed)*

------
https://chatgpt.com/codex/tasks/task_e_6893a3134da88327864df7e505ae8434