### PR TITLE
Add joining date validation for user accounts

### DIFF
--- a/app/Http/Controllers/Admin/UserAccountController.php
+++ b/app/Http/Controllers/Admin/UserAccountController.php
@@ -109,6 +109,7 @@ class UserAccountController extends Controller
             'email' => 'required|email|unique:user_accounts,email',
             'phone' => 'required|string|max:20|unique:user_accounts,phone',
             'status' => 'required|in:1,2',
+            'created_at' => 'required|date_format:d-m-Y',
         ]);
 
         if ($validator->fails()) {
@@ -118,9 +119,10 @@ class UserAccountController extends Controller
             ], 422);
         }
 
-        UserAccount::create(array_merge($validator->validated(), [
-            'user_type' => $data['user_type'],
-        ]));
+        $validated = $validator->validated();
+        $validated['user_type'] = $data['user_type'];
+        $validated['created_at'] = Carbon::createFromFormat('d-m-Y', $validated['created_at']);
+        UserAccount::create($validated);
 
         return response()->json([
             'status' => 'success',
@@ -162,6 +164,7 @@ class UserAccountController extends Controller
             'email' => 'required|email|unique:user_accounts,email,' . $user->id,
             'phone' => 'required|string|max:20|unique:user_accounts,phone,' . $user->id,
             'status' => 'required|in:1,2',
+            'created_at' => 'required|date_format:d-m-Y',
         ]);
 
         if ($validator->fails()) {
@@ -171,7 +174,9 @@ class UserAccountController extends Controller
             ], 422);
         }
 
-        $user->update($validator->validated());
+        $validated = $validator->validated();
+        $validated['created_at'] = Carbon::createFromFormat('d-m-Y', $validated['created_at']);
+        $user->update($validated);
 
         return response()->json([
             'status' => 'success',

--- a/app/Models/UserAccount.php
+++ b/app/Models/UserAccount.php
@@ -28,6 +28,7 @@ class UserAccount extends Model
         'is_verified',
         'product_and_services',
         'parent_id',
+        'created_at',
     ];
 
     protected $hidden = [

--- a/resources/views/ursbid-admin/user_accounts/create.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/create.blade.php
@@ -41,6 +41,11 @@
                             <div class="invalid-feedback" data-field="phone"></div>
                         </div>
                         <div class="mb-3">
+                            <label class="form-label">Joining Date</label>
+                            <input type="text" name="created_at" class="form-control" placeholder="dd-mm-yyyy" required>
+                            <div class="invalid-feedback" data-field="created_at"></div>
+                        </div>
+                        <div class="mb-3">
                             <label class="form-label">Status</label>
                             <select name="status" class="form-select" required>
                                 <option value="1">Active</option>
@@ -65,6 +70,12 @@ $(function(){
     $('#userForm').on('submit', function(e){
         e.preventDefault();
         $('.invalid-feedback').text('');
+        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        const joinDate = $('input[name="created_at"]').val();
+        if(!datePattern.test(joinDate)){
+            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+            return;
+        }
         $.ajax({
             url: '{{ route('super-admin.accounts.store', $type) }}',
             type: 'POST',

--- a/resources/views/ursbid-admin/user_accounts/edit.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/edit.blade.php
@@ -42,6 +42,11 @@
                             <div class="invalid-feedback" data-field="phone"></div>
                         </div>
                         <div class="mb-3">
+                            <label class="form-label">Joining Date</label>
+                            <input type="text" name="created_at" class="form-control" value="{{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}" placeholder="dd-mm-yyyy" required>
+                            <div class="invalid-feedback" data-field="created_at"></div>
+                        </div>
+                        <div class="mb-3">
                             <label class="form-label">Status</label>
                             <select name="status" class="form-select" required>
                                 <option value="1" {{ $user->status == '1' ? 'selected' : '' }}>Active</option>
@@ -66,6 +71,12 @@ $(function(){
     $('#userForm').on('submit', function(e){
         e.preventDefault();
         $('.invalid-feedback').text('');
+        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        const joinDate = $('input[name="created_at"]').val();
+        if(!datePattern.test(joinDate)){
+            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+            return;
+        }
         $.ajax({
             url: '{{ route('super-admin.accounts.update', [$type, $user->id]) }}',
             type: 'POST',


### PR DESCRIPTION
## Summary
- allow setting joining date for user accounts with dd-mm-yyyy format
- validate joining date on client and server during create/update
- permit created_at mass assignment in UserAccount model

## Testing
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_6893aa5483108327820cf84a44db9ce8