### PR TITLE
Enable multi user-type filters on account listings

### DIFF
--- a/resources/views/ursbid-admin/user_accounts/index.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/index.blade.php
@@ -1,5 +1,5 @@
 @extends('ursbid-admin.layouts.app')
-@section('title', $userType . ' List')
+@section('title', 'User Accounts')
 
 @section('content')
 <div class="container-fluid">
@@ -43,6 +43,14 @@
                             <div class="col-md-2">
                                 <label class="form-label">To Date</label>
                                 <input type="text" name="to_date" class="form-control" placeholder="dd-mm-yyyy">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">User Types</label>
+                                <select name="user_types[]" class="form-select" multiple>
+                                    @foreach($userTypeOptions as $opt)
+                                        <option value="{{ $opt['code'] }}">{{ $opt['label'] }}</option>
+                                    @endforeach
+                                </select>
                             </div>
                             <div class="col-12 text-end">
                                 <button type="submit" class="btn btn-primary">Filter</button>
@@ -95,7 +103,9 @@ $(function(){
         const email = $('input[name="email"]').val();
         const from = $('input[name="from_date"]').val();
         const to = $('input[name="to_date"]').val();
+        const userTypes = $('select[name="user_types[]"]').val() || [];
         const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        const validTypes = ['1','2','3','4'];
         if(name.length > 255){
             toastr.error('Name may not be greater than 255 characters.');
             return;
@@ -111,6 +121,12 @@ $(function(){
         if(to && !datePattern.test(to)){
             toastr.error('To date must be in dd-mm-yyyy format.');
             return;
+        }
+        for(let t of userTypes){
+            if(!validTypes.includes(t)){
+                toastr.error('Invalid user type selected.');
+                return;
+            }
         }
         loadList();
     });

--- a/resources/views/ursbid-admin/user_accounts/partials/table.blade.php
+++ b/resources/views/ursbid-admin/user_accounts/partials/table.blade.php
@@ -5,6 +5,7 @@
             <th>Name</th>
             <th>Email</th>
             <th>Phone</th>
+            <th>User Type</th>
             <th>Created Date</th>
             <th>Status</th>
             <th>Action</th>
@@ -17,6 +18,7 @@
                 <td>{{ $user->name }}</td>
                 <td>{{ $user->email }}</td>
                 <td>{{ $user->phone }}</td>
+                <td>{{ ucfirst($user->user_type) }}</td>
                 <td>{{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}</td>
                 <td>
                     @if($user->status == '1')
@@ -26,9 +28,10 @@
                     @endif
                 </td>
                 <td>
+                    @php $routeType = $typeRouteMap[$user->user_type] ?? ''; @endphp
                     <div class="d-flex gap-2">
-                        <a href="{{ route('super-admin.accounts.edit', [$type, $user->id]) }}" class="btn btn-soft-primary btn-sm">Edit</a>
-                        <a href="{{ route('super-admin.accounts.show', [$type, $user->id]) }}" class="btn btn-soft-info btn-sm">View</a>
+                        <a href="{{ route('super-admin.accounts.edit', [$routeType, $user->id]) }}" class="btn btn-soft-primary btn-sm">Edit</a>
+                        <a href="{{ route('super-admin.accounts.show', [$routeType, $user->id]) }}" class="btn btn-soft-info btn-sm">View</a>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- allow filtering user accounts by multiple user types with validation
- add user-type multi-select in account list filter and client-side checks
- show user type in listings with proper edit/view routes

## Testing
- `php -l app/Http/Controllers/Admin/UserAccountController.php`
- `php -l resources/views/ursbid-admin/user_accounts/index.blade.php`
- `php -l resources/views/ursbid-admin/user_accounts/partials/table.blade.php`
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*


------
https://chatgpt.com/codex/tasks/task_e_6893ae9ebf2c83278fdc39d7fae97804