### PR TITLE
feat: add category and subcategory management

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -24,12 +24,14 @@ class CategoryController extends Controller
     public function store(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'title' => 'required|string|max:255|unique:category,title',
-            'post_date' => 'required|date_format:d-m-Y',
+            'name' => 'required|string|max:255|unique:categories,name',
+            'description' => 'required|string',
+            'tags' => 'nullable|string',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
             'meta_title' => 'nullable|string|max:255',
             'meta_keywords' => 'nullable|string|max:255',
             'meta_description' => 'nullable|string',
+            'status' => 'required|in:1,2',
         ]);
 
         if ($validator->fails()) {
@@ -40,7 +42,10 @@ class CategoryController extends Controller
         }
 
         $data = $validator->validated();
-        $data['slug'] = Str::slug($data['title']);
+        $data['slug'] = Str::slug($data['name']);
+        if(isset($data['tags'])){
+            $data['tags'] = json_encode(array_map('trim', explode(',', $data['tags'])));
+        }
 
         if ($request->hasFile('image')) {
             $file = $request->file('image');
@@ -69,12 +74,14 @@ class CategoryController extends Controller
         $category = Category::findOrFail($id);
 
         $validator = Validator::make($request->all(), [
-            'title' => 'required|string|max:255|unique:category,title,' . $category->id,
-            'post_date' => 'required|date_format:d-m-Y',
+            'name' => 'required|string|max:255|unique:categories,name,' . $category->id,
+            'description' => 'required|string',
+            'tags' => 'nullable|string',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
             'meta_title' => 'nullable|string|max:255',
             'meta_keywords' => 'nullable|string|max:255',
             'meta_description' => 'nullable|string',
+            'status' => 'required|in:1,2',
         ]);
 
         if ($validator->fails()) {
@@ -85,7 +92,10 @@ class CategoryController extends Controller
         }
 
         $data = $validator->validated();
-        $data['slug'] = Str::slug($data['title']);
+        $data['slug'] = Str::slug($data['name']);
+        if(isset($data['tags'])){
+            $data['tags'] = json_encode(array_map('trim', explode(',', $data['tags'])));
+        }
 
         if ($request->hasFile('image')) {
             if ($category->image && file_exists(public_path($category->image))) {

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Category extends Model
+class SubCategory extends Model
 {
-    protected $table = 'categories';
+    protected $table = 'sub_categories';
 
     protected $fillable = [
+        'category_id',
         'slug',
         'name',
         'image',
@@ -18,9 +19,15 @@ class Category extends Model
         'meta_keywords',
         'meta_description',
         'status',
+        'order_by',
     ];
 
     protected $casts = [
         'tags' => 'array',
     ];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/database/migrations/2025_08_10_000000_create_categories_table.php
+++ b/database/migrations/2025_08_10_000000_create_categories_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique()->comment('category identifier in urls');
+            $table->string('name');
+            $table->text('image')->nullable();
+            $table->text('description');
+            $table->json('tags');
+            $table->text('meta_title')->nullable();
+            $table->text('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->enum('status', ['1','2'])->default('1');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_08_10_000001_create_sub_categories_table.php
+++ b/database/migrations/2025_08_10_000001_create_sub_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sub_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('categories');
+            $table->string('slug')->unique()->comment('subcategory identifier in urls');
+            $table->string('name');
+            $table->text('image')->nullable();
+            $table->text('description');
+            $table->json('tags');
+            $table->text('meta_title')->nullable();
+            $table->text('meta_keywords')->nullable();
+            $table->text('meta_description')->nullable();
+            $table->enum('status', ['1','2'])->default('1');
+            $table->integer('order_by')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sub_categories');
+    }
+};

--- a/resources/views/ursbid-admin/category/create.blade.php
+++ b/resources/views/ursbid-admin/category/create.blade.php
@@ -25,18 +25,26 @@
                         @csrf
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Title</label>
+                                <label class="form-label fw-semibold">Name</label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="title" class="form-control" placeholder="Enter Title">
+                                <input type="text" name="name" class="form-control" placeholder="Enter Name">
                             </div>
                         </div>
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Post Date</label>
+                                <label class="form-label fw-semibold">Description</label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="post_date" id="post_date" class="form-control" placeholder="dd-mm-yyyy">
+                                <textarea name="description" class="form-control" rows="3" placeholder="Enter Description"></textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Tags</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="tags" class="form-control" placeholder="tag1, tag2">
                             </div>
                         </div>
                         <div class="row mb-3 align-items-center">
@@ -71,6 +79,17 @@
                                 <textarea name="meta_description" class="form-control" rows="3" placeholder="Enter Meta Description"></textarea>
                             </div>
                         </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1">Active</option>
+                                    <option value="2">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col-md-12 text-end">
                                 <button type="submit" id="saveBtn" class="btn btn-primary">Save</button>
@@ -85,24 +104,17 @@
 @endsection
 
 @push('styles')
-<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 @endpush
 
 @push('scripts')
-<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 $(function(){
-    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
-
-    $.validator.addMethod('dmy', function(value){
-        return /^\d{2}-\d{2}-\d{4}$/.test(value);
-    }, 'Please enter a date in the format dd-mm-yyyy');
-
     $('#categoryForm').validate({
         rules:{
-            title:{ required:true },
-            post_date:{ required:true, dmy:true }
+            name:{ required:true },
+            description:{ required:true },
+            status:{ required:true }
         },
         submitHandler:function(form){
             $('#saveBtn').prop('disabled',true).text('Saving...');

--- a/resources/views/ursbid-admin/category/edit.blade.php
+++ b/resources/views/ursbid-admin/category/edit.blade.php
@@ -26,18 +26,26 @@
                         @method('PUT')
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Title</label>
+                                <label class="form-label fw-semibold">Name</label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="title" class="form-control" value="{{ $category->title }}" placeholder="Enter Title">
+                                <input type="text" name="name" class="form-control" value="{{ $category->name }}" placeholder="Enter Name">
                             </div>
                         </div>
                         <div class="row mb-3 align-items-center">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Post Date</label>
+                                <label class="form-label fw-semibold">Description</label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="post_date" id="post_date" class="form-control" value="{{ $category->post_date }}" placeholder="dd-mm-yyyy">
+                                <textarea name="description" class="form-control" rows="3" placeholder="Enter Description">{{ $category->description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Tags</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="tags" class="form-control" value="{{ implode(',', $category->tags ?? []) }}" placeholder="tag1, tag2">
                             </div>
                         </div>
                         <div class="row mb-3 align-items-center">
@@ -77,6 +85,17 @@
                                 <textarea name="meta_description" class="form-control" rows="3" placeholder="Enter Meta Description">{{ $category->meta_description }}</textarea>
                             </div>
                         </div>
+                        <div class="row mb-3 align-items-center">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Status</label>
+                            </div>
+                            <div class="col-md-8">
+                                <select name="status" class="form-control">
+                                    <option value="1" {{ $category->status == '1' ? 'selected' : '' }}>Active</option>
+                                    <option value="2" {{ $category->status == '2' ? 'selected' : '' }}>Inactive</option>
+                                </select>
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col-md-12 text-end">
                                 <button type="submit" id="updateBtn" class="btn btn-primary">Update</button>
@@ -91,24 +110,17 @@
 @endsection
 
 @push('styles')
-<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 @endpush
 
 @push('scripts')
-<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 $(function(){
-    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
-
-    $.validator.addMethod('dmy', function(value){
-        return /^\d{2}-\d{2}-\d{4}$/.test(value);
-    }, 'Please enter a date in the format dd-mm-yyyy');
-
     $('#categoryForm').validate({
         rules:{
-            title:{ required:true },
-            post_date:{ required:true, dmy:true }
+            name:{ required:true },
+            description:{ required:true },
+            status:{ required:true }
         },
         submitHandler:function(form){
             $('#updateBtn').prop('disabled',true).text('Updating...');

--- a/resources/views/ursbid-admin/category/list.blade.php
+++ b/resources/views/ursbid-admin/category/list.blade.php
@@ -33,8 +33,8 @@
                         <thead class="bg-light-subtle">
                             <tr>
                                 <th>S.No</th>
-                                <th>Category Title</th>
-                                <th>Post Date</th>
+                                <th>Category Name</th>
+                                <th>Created</th>
                                 <th>Status</th>
                                 <th>Action</th>
                             </tr>
@@ -46,15 +46,14 @@
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
-                                           <img src="{{ $category->image ? asset('public/'.$category->image) : asset('assets/images/default-category.png') }}" alt="{{ $category->title }}"  class="avatar-md rounded border border-light border-3" style="object-fit: cover;">
-
+                                           <img src="{{ $category->image ? asset('public/'.$category->image) : asset('assets/images/default-category.png') }}" alt="{{ $category->name }}"  class="avatar-md rounded border border-light border-3" style="object-fit: cover;">
                                         </div>
                                         <div>
-                                            <a href="#!" class="text-dark fw-medium fs-15">{{ $category->title }}</a>
+                                            <a href="#!" class="text-dark fw-medium fs-15">{{ $category->name }}</a>
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $category->post_date ? \Carbon\Carbon::parse($category->post_date)->format('d-m-Y') : '' }}</td>
+                                <td>{{ $category->created_at ? \Carbon\Carbon::parse($category->created_at)->format('d-m-Y') : '' }}</td>
                                 <td>
                                     @if($category->status == '1')
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>

--- a/resources/views/ursbid-admin/sub_categories/create.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/create.blade.php
@@ -10,10 +10,10 @@
                         @csrf
                         <div class="row mb-3">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                                <label class="form-label fw-semibold">Name<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="title" class="form-control" required>
+                                <input type="text" name="name" class="form-control" required>
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -21,20 +21,28 @@
                                 <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <select name="cat_id" class="form-control" required>
+                                <select name="category_id" class="form-control" required>
                                     <option value="">Select Category</option>
                                     @foreach($categories as $cat)
-                                        <option value="{{ $cat->id }}">{{ $cat->title }}</option>
+                                        <option value="{{ $cat->id }}">{{ $cat->name ?? $cat->title }}</option>
                                     @endforeach
                                 </select>
                             </div>
                         </div>
                         <div class="row mb-3">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                                <label class="form-label fw-semibold">Description<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="post_date" id="post_date" class="form-control" placeholder="dd-mm-yyyy" required>
+                                <textarea name="description" class="form-control" rows="3" required></textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Tags</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="tags" class="form-control" placeholder="tag1, tag2">
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -52,7 +60,7 @@
                             <div class="col-md-8">
                                 <select name="status" class="form-control">
                                     <option value="1">Active</option>
-                                    <option value="0">Inactive</option>
+                                    <option value="2">Inactive</option>
                                 </select>
                             </div>
                         </div>
@@ -98,24 +106,17 @@
     </div>
 </div>
 @push('styles')
-<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 @endpush
 @push('scripts')
-<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 $(function(){
-    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
-
-    $.validator.addMethod('dmy', function(value){
-        return /^\d{2}-\d{2}-\d{4}$/.test(value);
-    }, 'Please enter a date in the format dd-mm-yyyy');
-
     $('#subCategoryForm').validate({
         rules:{
-            title:{ required:true },
-            cat_id:{ required:true },
-            post_date:{ required:true, dmy:true }
+            name:{ required:true },
+            category_id:{ required:true },
+            description:{ required:true },
+            status:{ required:true }
         },
         submitHandler:function(form){
             $('#saveBtn').attr('disabled', true).text('Saving...');

--- a/resources/views/ursbid-admin/sub_categories/edit.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/edit.blade.php
@@ -10,10 +10,10 @@
                         @csrf
                         <div class="row mb-3">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Title<span class="text-danger">*</span></label>
+                                <label class="form-label fw-semibold">Name<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="title" class="form-control" value="{{ $sub->title }}" required>
+                                <input type="text" name="name" class="form-control" value="{{ $sub->name }}" required>
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -21,20 +21,28 @@
                                 <label class="form-label fw-semibold">Category<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <select name="cat_id" class="form-control" required>
+                                <select name="category_id" class="form-control" required>
                                     <option value="">Select Category</option>
                                     @foreach($categories as $cat)
-                                        <option value="{{ $cat->id }}" {{ $sub->cat_id == $cat->id ? 'selected' : '' }}>{{ $cat->title }}</option>
+                                        <option value="{{ $cat->id }}" {{ $sub->category_id == $cat->id ? 'selected' : '' }}>{{ $cat->name ?? $cat->title }}</option>
                                     @endforeach
                                 </select>
                             </div>
                         </div>
                         <div class="row mb-3">
                             <div class="col-md-4">
-                                <label class="form-label fw-semibold">Post Date<span class="text-danger">*</span></label>
+                                <label class="form-label fw-semibold">Description<span class="text-danger">*</span></label>
                             </div>
                             <div class="col-md-8">
-                                <input type="text" name="post_date" id="post_date" class="form-control" value="{{ $sub->post_date }}" placeholder="dd-mm-yyyy" required>
+                                <textarea name="description" class="form-control" rows="3" required>{{ $sub->description }}</textarea>
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Tags</label>
+                            </div>
+                            <div class="col-md-8">
+                                <input type="text" name="tags" class="form-control" value="{{ implode(',', $sub->tags ? json_decode($sub->tags) : []) }}" placeholder="tag1, tag2">
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -51,8 +59,8 @@
                             </div>
                             <div class="col-md-8">
                                 <select name="status" class="form-control">
-                                    <option value="1" {{ $sub->status == 1 ? 'selected' : '' }}>Active</option>
-                                    <option value="0" {{ $sub->status == 0 ? 'selected' : '' }}>Inactive</option>
+                                    <option value="1" {{ $sub->status == '1' ? 'selected' : '' }}>Active</option>
+                                    <option value="2" {{ $sub->status == '2' ? 'selected' : '' }}>Inactive</option>
                                 </select>
                             </div>
                         </div>
@@ -104,24 +112,17 @@
     </div>
 </div>
 @push('styles')
-<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 @endpush
 @push('scripts')
-<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 $(function(){
-    $('#post_date').datepicker({ dateFormat: 'dd-mm-yy' });
-
-    $.validator.addMethod('dmy', function(value){
-        return /^\d{2}-\d{2}-\d{4}$/.test(value);
-    }, 'Please enter a date in the format dd-mm-yyyy');
-
     $('#subCategoryForm').validate({
         rules:{
-            title:{ required:true },
-            cat_id:{ required:true },
-            post_date:{ required:true, dmy:true }
+            name:{ required:true },
+            category_id:{ required:true },
+            description:{ required:true },
+            status:{ required:true }
         },
         submitHandler:function(form){
             $('#saveBtn').attr('disabled', true).text('Updating...');

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -73,7 +73,7 @@
                     <div>
                         <h4 class="card-title mb-0">All Sub Categories List</h4>
                     </div>
-                    <a href="{{ route('super-admin.sub-categories.create') }}" class="btn btn-sm btn-primary">Add Sub Category</a>
+                    <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#subCategoryModal">Add Sub Category</button>
                 </div>
 
                 <div class="table-responsive">
@@ -81,9 +81,9 @@
                         <thead class="bg-light-subtle">
                             <tr>
                                 <th>S.No</th>
-                                <th>Sub Category Title</th>
+                                <th>Sub Category Name</th>
                                 <th>Category</th>
-                                <th>Post Date</th>
+                                <th>Created</th>
                                 <th>Status</th>
                                 <th>Action</th>
                             </tr>
@@ -95,17 +95,17 @@
                                 <td>
                                     <div class="d-flex align-items-center gap-2">
                                         <div>
-                                            <img src="{{ $sub->image ? asset('public/'.$sub->image) : asset('public/uploads/no-image.jpg') }}" alt="{{ $sub->title }}" class="avatar-md rounded border border-light border-3" style="object-fit: cover;">
+                                            <img src="{{ $sub->image ? asset('public/'.$sub->image) : asset('public/uploads/no-image.jpg') }}" alt="{{ $sub->name }}" class="avatar-md rounded border border-light border-3" style="object-fit: cover;">
                                         </div>
                                         <div>
-                                            <a href="#!" class="text-dark fw-medium fs-15">{{ $sub->title }}</a>
+                                            <a href="#!" class="text-dark fw-medium fs-15">{{ $sub->name }}</a>
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $sub->category_title }}</td>
-                                <td>{{ $sub->post_date ? \Carbon\Carbon::parse($sub->post_date)->format('d-m-Y') : '' }}</td>
+                                <td>{{ $sub->category_name }}</td>
+                                <td>{{ $sub->created_at ? \Carbon\Carbon::parse($sub->created_at)->format('d-m-Y') : '' }}</td>
                                 <td>
-                                    @if($sub->status == 1)
+                                    @if($sub->status == '1')
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
                                     @else
                                         <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
@@ -136,9 +136,83 @@
         </div>
     </div>
 </div>
+
+<!-- Modal -->
+<div class="modal fade" id="subCategoryModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Add Sub Category</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="subCategoryForm" enctype="multipart/form-data">
+          @csrf
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Name<span class="text-danger">*</span></label></div>
+            <div class="col-md-8"><input type="text" name="name" class="form-control" required></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Category<span class="text-danger">*</span></label></div>
+            <div class="col-md-8">
+              <select name="category_id" class="form-control" required>
+                <option value="">Select Category</option>
+                @foreach($categories as $cat)
+                  <option value="{{ $cat->id }}">{{ $cat->name }}</option>
+                @endforeach
+              </select>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Description<span class="text-danger">*</span></label></div>
+            <div class="col-md-8"><textarea name="description" class="form-control" rows="3" required></textarea></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Tags</label></div>
+            <div class="col-md-8"><input type="text" name="tags" class="form-control" placeholder="tag1, tag2"></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Order By</label></div>
+            <div class="col-md-8"><input type="number" name="order_by" class="form-control"></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Status</label></div>
+            <div class="col-md-8">
+              <select name="status" class="form-control">
+                <option value="1">Active</option>
+                <option value="2">Inactive</option>
+              </select>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Image</label></div>
+            <div class="col-md-8"><input type="file" name="image" class="form-control"></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Meta Title</label></div>
+            <div class="col-md-8"><input type="text" name="meta_title" class="form-control"></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Meta Keywords</label></div>
+            <div class="col-md-8"><input type="text" name="meta_keywords" class="form-control"></div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-md-4"><label class="form-label fw-semibold">Meta Description</label></div>
+            <div class="col-md-8"><textarea name="meta_description" class="form-control" rows="3"></textarea></div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="submit" form="subCategoryForm" id="saveSubBtn" class="btn btn-primary">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
 @endsection
 
 @push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 $(function(){
     $('.deleteBtn').on('click', function(){
@@ -157,6 +231,40 @@ $(function(){
                 toastr.error('Unable to delete record');
             }
         });
+    });
+
+    $('#subCategoryForm').validate({
+        rules:{
+            name:{ required:true },
+            category_id:{ required:true },
+            description:{ required:true },
+            status:{ required:true }
+        },
+        submitHandler:function(form){
+            $('#saveSubBtn').prop('disabled',true).text('Saving...');
+            $.ajax({
+                url: "{{ route('super-admin.sub-categories.store') }}",
+                type: 'POST',
+                data: new FormData(form),
+                processData: false,
+                contentType: false,
+                success: function(res){
+                    toastr.success(res.message);
+                    $('#saveSubBtn').prop('disabled',false).text('Save');
+                    $('#subCategoryModal').modal('hide');
+                    location.reload();
+                },
+                error: function(xhr){
+                    let err = 'Error saving data';
+                    if(xhr.responseJSON && xhr.responseJSON.errors){
+                        err = Object.values(xhr.responseJSON.errors).map(e => e.join(', ')).join('<br>');
+                    }
+                    toastr.error(err);
+                    $('#saveSubBtn').prop('disabled',false).text('Save');
+                }
+            });
+            return false;
+        }
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- add migrations for categories and sub_categories
- implement admin controllers and models for new schema
- introduce modal-based subcategory creation with ajax validation

## Testing
- `composer install` *(fails: Your lock file does not contain a compatible set of packages. nette/schema v1.2.5 requires php 7.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement.)*

------
https://chatgpt.com/codex/tasks/task_e_6893c7759ad48327afee22e735d394fb