### PR TITLE
Remove created date from role creation form

### DIFF
--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -70,7 +70,6 @@ class RoleController extends Controller
         $validator = Validator::make($request->all(), [
             'role_name' => 'required|string|max:100',
             'status' => 'required|in:1,2',
-            'created_at' => 'required|date_format:d-m-Y',
         ]);
 
         if ($validator->fails()) {
@@ -81,7 +80,6 @@ class RoleController extends Controller
         }
 
         $validated = $validator->validated();
-        $validated['created_at'] = Carbon::createFromFormat('d-m-Y', $validated['created_at']);
         Role::create($validated);
 
         return response()->json([

--- a/resources/views/ursbid-admin/roles/create.blade.php
+++ b/resources/views/ursbid-admin/roles/create.blade.php
@@ -30,11 +30,6 @@
                             <div class="invalid-feedback" data-field="role_name"></div>
                         </div>
                         <div class="mb-3">
-                            <label class="form-label">Created Date</label>
-                            <input type="text" name="created_at" class="form-control" placeholder="dd-mm-yyyy" required>
-                            <div class="invalid-feedback" data-field="created_at"></div>
-                        </div>
-                        <div class="mb-3">
                             <label class="form-label">Status</label>
                             <select name="status" class="form-select" required>
                                 <option value="1">Active</option>
@@ -59,10 +54,14 @@ $(function(){
     $('#roleForm').on('submit', function(e){
         e.preventDefault();
         $('.invalid-feedback').text('');
-        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
-        const created = $('input[name="created_at"]').val();
-        if(!datePattern.test(created)){
-            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+        const roleName = $('input[name="role_name"]').val().trim();
+        const status = $('select[name="status"]').val();
+        if(!roleName){
+            $('[data-field="role_name"]').text('Role name is required.');
+            return;
+        }
+        if(!status){
+            $('[data-field="status"]').text('Status is required.');
             return;
         }
         $.ajax({


### PR DESCRIPTION
## Summary
- drop created date field and client-side checks from role creation view
- simplify role controller store validation

## Testing
- `composer install` *(fails: nette/schema requires php 7.1 - 8.3)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dea1560c8327a99674a24e4982e1