### PR TITLE
Add edit and delete features for roles

### DIFF
--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -87,4 +87,47 @@ class RoleController extends Controller
             'message' => 'Role created successfully.',
         ]);
     }
+
+    public function edit(int $id)
+    {
+        $role = Role::findOrFail($id);
+        return view('ursbid-admin.roles.edit', [
+            'role' => $role,
+        ]);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $role = Role::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'role_name' => 'required|string|max:100|unique:roles,role_name,' . $role->id,
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $role->update($validator->validated());
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Role updated successfully.',
+        ]);
+    }
+
+    public function destroy(int $id)
+    {
+        $role = Role::findOrFail($id);
+        $role->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Role deleted successfully.',
+        ]);
+    }
 }

--- a/resources/views/ursbid-admin/roles/edit.blade.php
+++ b/resources/views/ursbid-admin/roles/edit.blade.php
@@ -1,0 +1,90 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Role')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Edit Role</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.roles.index') }}">Role List</a></li>
+                    <li class="breadcrumb-item active">Edit</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Edit Role</h4>
+                </div>
+                <form id="roleForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Role Name</label>
+                            <input type="text" name="role_name" class="form-control" value="{{ $role->role_name }}" required>
+                            <div class="invalid-feedback" data-field="role_name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1" {{ $role->status == '1' ? 'selected' : '' }}>Active</option>
+                                <option value="2" {{ $role->status == '2' ? 'selected' : '' }}>Inactive</option>
+                            </select>
+                            <div class="invalid-feedback" data-field="status"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#roleForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        const roleName = $('input[name="role_name"]').val().trim();
+        const status = $('select[name="status"]').val();
+        if(!roleName){
+            $('[data-field="role_name"]').text('Role name is required.');
+            return;
+        }
+        if(!status){
+            $('[data-field="status"]').text('Status is required.');
+            return;
+        }
+        $.ajax({
+            url: '{{ route('super-admin.roles.update', $role->id) }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+                window.location.href = '{{ route('super-admin.roles.index') }}';
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for(let field in errors){
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Update failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/roles/index.blade.php
+++ b/resources/views/ursbid-admin/roles/index.blade.php
@@ -73,6 +73,7 @@ $(function(){
             data: $('#filterForm').serialize(),
             success: function(res){
                 $('#listContainer').html(res.html);
+                bindDeleteEvents();
             },
             error: function(xhr){
                 if(xhr.status === 422){
@@ -106,6 +107,25 @@ $(function(){
     });
 
     loadList();
+
+    function bindDeleteEvents(){
+        $('.deleteBtn').on('click', function(){
+            if(!confirm('Are you sure want to delete?')) return;
+            const id = $(this).data('id');
+            $.ajax({
+                url: '/super-admin/roles/' + id,
+                type: 'DELETE',
+                data: { _token: '{{ csrf_token() }}' },
+                success: function(res){
+                    toastr.success(res.message);
+                    loadList();
+                },
+                error: function(){
+                    toastr.error('Unable to delete role');
+                }
+            });
+        });
+    }
 });
 </script>
 @endpush

--- a/resources/views/ursbid-admin/roles/partials/table.blade.php
+++ b/resources/views/ursbid-admin/roles/partials/table.blade.php
@@ -5,6 +5,7 @@
             <th>Role Name</th>
             <th>Status</th>
             <th>Created At</th>
+            <th>Action</th>
         </tr>
     </thead>
     <tbody>
@@ -14,10 +15,16 @@
             <td>{{ $role->role_name }}</td>
             <td>{{ $role->status == '1' ? 'Active' : 'Inactive' }}</td>
             <td>{{ $role->created_at->format('d-m-Y') }}</td>
+            <td>
+                <div class="d-flex gap-2">
+                    <a href="{{ route('super-admin.roles.edit', $role->id) }}" class="btn btn-soft-primary btn-sm">Edit</a>
+                    <button type="button" class="btn btn-soft-danger btn-sm deleteBtn" data-id="{{ $role->id }}">Delete</button>
+                </div>
+            </td>
         </tr>
         @empty
         <tr>
-            <td colspan="4" class="text-center">No roles found.</td>
+            <td colspan="5" class="text-center">No roles found.</td>
         </tr>
         @endforelse
     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -465,6 +465,9 @@ Route::prefix('super-admin/roles')->name('super-admin.roles.')->group(function (
     Route::get('/list', [RoleController::class, 'list'])->name('list');
     Route::get('/create', [RoleController::class, 'create'])->name('create');
     Route::post('/', [RoleController::class, 'store'])->name('store');
+    Route::get('/{id}/edit', [RoleController::class, 'edit'])->name('edit');
+    Route::put('/{id}', [RoleController::class, 'update'])->name('update');
+    Route::delete('/{id}', [RoleController::class, 'destroy'])->name('destroy');
 });
 
 


### PR DESCRIPTION
## Summary
- add edit and delete routes and controller actions for roles
- provide AJAX-enabled edit form with client-side validation
- show edit/delete controls in role list and handle deletions via AJAX

## Testing
- `composer install --no-interaction --no-progress` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3, current php 8.4.11)*
- `php -l app/Http/Controllers/Admin/RoleController.php`
- `php -l routes/web.php`


------
https://chatgpt.com/codex/tasks/task_e_6893e0acf1b08327ab71a133c6a07bf3