### PR TITLE
Add user management CRUD with role mapping

### DIFF
--- a/app/Http/Controllers/Admin/UsermanagementController.php
+++ b/app/Http/Controllers/Admin/UsermanagementController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserAccount;
+use App\Models\Role;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Carbon\Carbon;
+
+class UsermanagementController extends Controller
+{
+    public function index()
+    {
+        return view('ursbid-admin.user_management.index');
+    }
+
+    public function list()
+    {
+        $users = UserAccount::with('roles')->orderByDesc('id')->get();
+        $html = view('ursbid-admin.user_management.partials.table', [
+            'users' => $users,
+        ])->render();
+
+        return response()->json([
+            'status' => 'success',
+            'html' => $html,
+        ]);
+    }
+
+    public function create()
+    {
+        return view('ursbid-admin.user_management.create', [
+            'roles' => Role::orderBy('role_name')->get(),
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:user_accounts,email',
+            'phone' => 'required|string|max:20|unique:user_accounts,phone',
+            'status' => 'required|in:1,2',
+            'created_at' => 'required|date_format:d-m-Y',
+            'roles' => 'nullable|array',
+            'roles.*' => 'exists:roles,id',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $validated = $validator->validated();
+        $validated['parent_id'] = auth()->id();
+        $validated['user_type'] = 'admin';
+        $validated['password'] = bcrypt('password');
+        $validated['created_at'] = Carbon::createFromFormat('d-m-Y', $validated['created_at']);
+
+        $user = UserAccount::create($validated);
+
+        if ($request->filled('roles')) {
+            $user->roles()->sync($request->roles);
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'User created successfully.',
+        ]);
+    }
+
+    public function edit(int $id)
+    {
+        $user = UserAccount::with('roles')->findOrFail($id);
+        return view('ursbid-admin.user_management.edit', [
+            'user' => $user,
+            'roles' => Role::orderBy('role_name')->get(),
+        ]);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $user = UserAccount::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:user_accounts,email,' . $user->id,
+            'phone' => 'required|string|max:20|unique:user_accounts,phone,' . $user->id,
+            'status' => 'required|in:1,2',
+            'created_at' => 'required|date_format:d-m-Y',
+            'roles' => 'nullable|array',
+            'roles.*' => 'exists:roles,id',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $validated = $validator->validated();
+        $validated['created_at'] = Carbon::createFromFormat('d-m-Y', $validated['created_at']);
+        $user->update($validated);
+
+        if ($request->filled('roles')) {
+            $user->roles()->sync($request->roles);
+        } else {
+            $user->roles()->detach();
+        }
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'User updated successfully.',
+        ]);
+    }
+
+    public function destroy(int $id)
+    {
+        $user = UserAccount::findOrFail($id);
+        $user->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'User deleted successfully.',
+        ]);
+    }
+}
+

--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -151,6 +151,15 @@
             </li>
 
             <li class="nav-item">
+                <a class="nav-link {{ request()->is('super-admin/user-management*') ? 'active' : '' }}" href="{{ route('super-admin.user-management.index') }}">
+                    <span class="nav-icon">
+                        <i class="ri-user-settings-line"></i>
+                    </span>
+                    <span class="nav-text">User Management</span>
+                </a>
+            </li>
+
+            <li class="nav-item">
                 <a class="nav-link {{ request()->is('super-admin/testimonials*') ? 'active' : '' }}" href="{{ route('super-admin.testimonials.index') }}">
                     <span class="nav-icon">
                         <i class="ri-chat-1-line"></i>

--- a/resources/views/ursbid-admin/user_management/create.blade.php
+++ b/resources/views/ursbid-admin/user_management/create.blade.php
@@ -1,0 +1,117 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Add User')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Add User</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.user-management.index') }}">User List</a></li>
+                    <li class="breadcrumb-item active">Add</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Add User</h4>
+                </div>
+                <form id="userForm">
+                    @csrf
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" required>
+                            <div class="invalid-feedback" data-field="name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" required>
+                            <div class="invalid-feedback" data-field="email"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" required>
+                            <div class="invalid-feedback" data-field="phone"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Roles</label>
+                            <select name="roles[]" class="form-select" multiple>
+                                @foreach($roles as $role)
+                                    <option value="{{ $role->id }}">{{ $role->role_name }}</option>
+                                @endforeach
+                            </select>
+                            <div class="invalid-feedback" data-field="roles"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Joining Date</label>
+                            <input type="text" name="created_at" class="form-control" placeholder="dd-mm-yyyy" required>
+                            <div class="invalid-feedback" data-field="created_at"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1">Active</option>
+                                <option value="2">Inactive</option>
+                            </select>
+                            <div class="invalid-feedback" data-field="status"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#userForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        const joinDate = $('input[name="created_at"]').val();
+        if(!datePattern.test(joinDate)){
+            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+            return;
+        }
+        const roles = $('select[name="roles[]"]').val() || [];
+        for(let r of roles){
+            if(!/^\d+$/.test(r)){
+                $('[data-field="roles"]').text('Invalid role selected.');
+                return;
+            }
+        }
+        $.ajax({
+            url: '{{ route('super-admin.user-management.store') }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+                $('#userForm')[0].reset();
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for(let field in errors){
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Creation failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_management/edit.blade.php
+++ b/resources/views/ursbid-admin/user_management/edit.blade.php
@@ -1,0 +1,117 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit User')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Edit User</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.user-management.index') }}">User List</a></li>
+                    <li class="breadcrumb-item active">Edit</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Edit User</h4>
+                </div>
+                <form id="userForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" value="{{ $user->name }}" required>
+                            <div class="invalid-feedback" data-field="name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" value="{{ $user->email }}" required>
+                            <div class="invalid-feedback" data-field="email"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Phone</label>
+                            <input type="text" name="phone" class="form-control" value="{{ $user->phone }}" required>
+                            <div class="invalid-feedback" data-field="phone"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Roles</label>
+                            <select name="roles[]" class="form-select" multiple>
+                                @foreach($roles as $role)
+                                    <option value="{{ $role->id }}" @if($user->roles->contains($role->id)) selected @endif>{{ $role->role_name }}</option>
+                                @endforeach
+                            </select>
+                            <div class="invalid-feedback" data-field="roles"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Joining Date</label>
+                            <input type="text" name="created_at" class="form-control" value="{{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}" placeholder="dd-mm-yyyy" required>
+                            <div class="invalid-feedback" data-field="created_at"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Status</label>
+                            <select name="status" class="form-select" required>
+                                <option value="1" @if($user->status == '1') selected @endif>Active</option>
+                                <option value="2" @if($user->status == '2') selected @endif>Inactive</option>
+                            </select>
+                            <div class="invalid-feedback" data-field="status"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#userForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        const datePattern = /^\d{2}-\d{2}-\d{4}$/;
+        const joinDate = $('input[name="created_at"]').val();
+        if(!datePattern.test(joinDate)){
+            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+            return;
+        }
+        const roles = $('select[name="roles[]"]').val() || [];
+        for(let r of roles){
+            if(!/^\d+$/.test(r)){
+                $('[data-field="roles"]').text('Invalid role selected.');
+                return;
+            }
+        }
+        $.ajax({
+            url: '{{ route('super-admin.user-management.update', $user->id) }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for(let field in errors){
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Update failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_management/index.blade.php
+++ b/resources/views/ursbid-admin/user_management/index.blade.php
@@ -1,0 +1,67 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'User Management')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">User List</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item active">User List</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                    <h4 class="card-title mb-0">Users</h4>
+                    <a href="{{ route('super-admin.user-management.create') }}" class="btn btn-sm btn-primary">Add User</a>
+                </div>
+                <div id="listContainer" class="table-responsive"></div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    function loadList(){
+        $.ajax({
+            url: '{{ route('super-admin.user-management.list') }}',
+            success: function(res){
+                $('#listContainer').html(res.html);
+            },
+            error: function(){
+                toastr.error('Unable to load list');
+            }
+        });
+    }
+
+    $(document).on('click', '.deleteBtn', function(){
+        if(!confirm('Are you sure?')) return;
+        var id = $(this).data('id');
+        $.ajax({
+            url: '{{ url('super-admin/user-management') }}/'+id,
+            type: 'DELETE',
+            data: {_token: '{{ csrf_token() }}'},
+            success: function(res){
+                toastr.success(res.message);
+                loadList();
+            },
+            error: function(){
+                toastr.error('Delete failed');
+            }
+        });
+    });
+
+    loadList();
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/user_management/partials/table.blade.php
+++ b/resources/views/ursbid-admin/user_management/partials/table.blade.php
@@ -1,0 +1,47 @@
+<table class="table align-middle text-nowrap table-hover table-centered mb-0">
+    <thead class="bg-light-subtle">
+        <tr>
+            <th>S.No</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Phone</th>
+            <th>Roles</th>
+            <th>Created Date</th>
+            <th>Status</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($users as $user)
+            <tr>
+                <td>{{ $loop->iteration }}</td>
+                <td>{{ $user->name }}</td>
+                <td>{{ $user->email }}</td>
+                <td>{{ $user->phone }}</td>
+                <td>
+                    @foreach($user->roles as $r)
+                        <span class="badge bg-info-subtle text-info me-1">{{ $r->role_name }}</span>
+                    @endforeach
+                </td>
+                <td>{{ \Carbon\Carbon::parse($user->created_at)->format('d-m-Y') }}</td>
+                <td>
+                    @if($user->status == '1')
+                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
+                    @else
+                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
+                    @endif
+                </td>
+                <td>
+                    <div class="d-flex gap-2">
+                        <a href="{{ route('super-admin.user-management.edit', $user->id) }}" class="btn btn-soft-primary btn-sm">Edit</a>
+                        <button type="button" class="btn btn-soft-danger btn-sm deleteBtn" data-id="{{ $user->id }}">Delete</button>
+                    </div>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="8" class="text-center">No records found.</td>
+            </tr>
+        @endforelse
+    </tbody>
+</table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -364,6 +364,7 @@ use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Admin\ProductBrandController;
 use App\Http\Controllers\Admin\UserAccountController;
 use App\Http\Controllers\Admin\RoleController;
+use App\Http\Controllers\Admin\UsermanagementController;
 
 
 
@@ -468,6 +469,16 @@ Route::prefix('super-admin/roles')->name('super-admin.roles.')->group(function (
     Route::get('/{id}/edit', [RoleController::class, 'edit'])->name('edit');
     Route::put('/{id}', [RoleController::class, 'update'])->name('update');
     Route::delete('/{id}', [RoleController::class, 'destroy'])->name('destroy');
+});
+
+Route::prefix('super-admin/user-management')->name('super-admin.user-management.')->group(function () {
+    Route::get('/', [UsermanagementController::class, 'index'])->name('index');
+    Route::get('/list', [UsermanagementController::class, 'list'])->name('list');
+    Route::get('/create', [UsermanagementController::class, 'create'])->name('create');
+    Route::post('/', [UsermanagementController::class, 'store'])->name('store');
+    Route::get('/{id}/edit', [UsermanagementController::class, 'edit'])->name('edit');
+    Route::put('/{id}', [UsermanagementController::class, 'update'])->name('update');
+    Route::delete('/{id}', [UsermanagementController::class, 'destroy'])->name('destroy');
 });
 
 


### PR DESCRIPTION
## Summary
- introduce `UsermanagementController` to list, create, update and delete `user_accounts` with role syncing and parent tracking
- add user management pages with AJAX validation and dd-mm-yyyy date support
- register user management routes and sidebar navigation entry

## Testing
- `composer install` *(failed: nette/schema v1.2.5 requires php 7.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement)*
- `php artisan test` *(failed: require(/workspace/ursbid-work/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893e3b3abbc83278da988ccec15c58e