### PR TITLE
Add role-based module permissions

### DIFF
--- a/app/Http/Controllers/Admin/RolePermissionController.php
+++ b/app/Http/Controllers/Admin/RolePermissionController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Module;
+use App\Models\Role;
+use App\Models\RolePermission;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class RolePermissionController extends Controller
+{
+    public function edit(int $id)
+    {
+        $role = Role::findOrFail($id);
+        $modules = Module::whereNull('parent_id')
+            ->where('status', '1')
+            ->with(['children' => function ($q) {
+                $q->where('status', '1');
+            }])->get();
+        $permissions = RolePermission::where('role_id', $id)->get()->keyBy('module_id');
+
+        return view('ursbid-admin.roles.permissions', [
+            'role' => $role,
+            'modules' => $modules,
+            'permissions' => $permissions,
+        ]);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $role = Role::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'permissions' => 'required|array',
+            'permissions.*.can_view' => 'nullable|in:1',
+            'permissions.*.can_add' => 'nullable|in:1',
+            'permissions.*.can_edit' => 'nullable|in:1',
+            'permissions.*.can_delete' => 'nullable|in:1',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $permissions = $request->input('permissions', []);
+        $moduleIds = Module::pluck('id')->toArray();
+
+        foreach ($permissions as $moduleId => $perm) {
+            if (!in_array($moduleId, $moduleIds)) {
+                continue;
+            }
+            RolePermission::updateOrCreate(
+                ['role_id' => $id, 'module_id' => $moduleId],
+                [
+                    'can_view' => isset($perm['can_view']) ? 1 : 0,
+                    'can_add' => isset($perm['can_add']) ? 1 : 0,
+                    'can_edit' => isset($perm['can_edit']) ? 1 : 0,
+                    'can_delete' => isset($perm['can_delete']) ? 1 : 0,
+                ]
+            );
+        }
+
+        RolePermission::where('role_id', $id)
+            ->whereNotIn('module_id', array_keys($permissions))
+            ->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Permissions updated successfully.',
+        ]);
+    }
+}

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Module extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'parent_id',
+        'status',
+    ];
+
+    public function children()
+    {
+        return $this->hasMany(Module::class, 'parent_id');
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(Module::class, 'parent_id');
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -23,4 +23,9 @@ class Role extends Model
     {
         return $this->belongsToMany(User::class, 'role_user');
     }
+
+    public function permissions()
+    {
+        return $this->hasMany(RolePermission::class);
+    }
 }

--- a/app/Models/RolePermission.php
+++ b/app/Models/RolePermission.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RolePermission extends Model
+{
+    use HasFactory;
+
+    protected $table = 'role_permission';
+
+    protected $fillable = [
+        'role_id',
+        'module_id',
+        'can_view',
+        'can_add',
+        'can_edit',
+        'can_delete',
+    ];
+
+    protected $casts = [
+        'can_view' => 'boolean',
+        'can_add' => 'boolean',
+        'can_edit' => 'boolean',
+        'can_delete' => 'boolean',
+    ];
+}

--- a/database/migrations/2025_08_12_000000_create_modules_table.php
+++ b/database/migrations/2025_08_12_000000_create_modules_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->enum('status', ['1', '2'])->default('1')->comment('1->Active, 2->Inactive');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+
+            $table->foreign('parent_id')->references('id')->on('modules')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('modules');
+    }
+};

--- a/database/migrations/2025_08_12_000001_create_role_permission_table.php
+++ b/database/migrations/2025_08_12_000001_create_role_permission_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_permission', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger('module_id');
+            $table->boolean('can_view')->default(false);
+            $table->boolean('can_add')->default(false);
+            $table->boolean('can_edit')->default(false);
+            $table->boolean('can_delete')->default(false);
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
+
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            $table->foreign('module_id')->references('id')->on('modules')->onDelete('cascade');
+            $table->unique(['role_id', 'module_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_permission');
+    }
+};

--- a/resources/views/ursbid-admin/roles/partials/table.blade.php
+++ b/resources/views/ursbid-admin/roles/partials/table.blade.php
@@ -17,6 +17,7 @@
             <td>{{ $role->created_at->format('d-m-Y') }}</td>
             <td>
                 <div class="d-flex gap-2">
+                    <a href="{{ route('super-admin.roles.permissions.edit', $role->id) }}" class="btn btn-soft-secondary btn-sm" title="Permissions"><i class="ri-lock-line"></i></a>
                     <a href="{{ route('super-admin.roles.edit', $role->id) }}" class="btn btn-soft-primary btn-sm">Edit</a>
                     <button type="button" class="btn btn-soft-danger btn-sm deleteBtn" data-id="{{ $role->id }}">Delete</button>
                 </div>

--- a/resources/views/ursbid-admin/roles/permissions.blade.php
+++ b/resources/views/ursbid-admin/roles/permissions.blade.php
@@ -1,0 +1,94 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Permissions')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="page-title-box">
+                <h4 class="mb-0 fw-semibold">Permissions - {{ $role->role_name }}</h4>
+                <ol class="breadcrumb mb-0">
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ route('super-admin.roles.index') }}">Role List</a></li>
+                    <li class="breadcrumb-item active">Permissions</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Manage Permissions</h4>
+                </div>
+                <form id="permissionForm">
+                    @csrf
+                    <div class="card-body">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Module/Submodule</th>
+                                    <th>Add</th>
+                                    <th>Edit</th>
+                                    <th>View</th>
+                                    <th>Delete</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($modules as $module)
+                                    <tr>
+                                        <td><strong>{{ $module->name }}</strong></td>
+                                        <td colspan="4"></td>
+                                    </tr>
+                                    @foreach($module->children as $child)
+                                        @php $perm = $permissions[$child->id] ?? null; @endphp
+                                        <tr>
+                                            <td class="ps-4">{{ $child->name }}</td>
+                                            <td><input type="checkbox" name="permissions[{{ $child->id }}][can_add]" {{ $perm && $perm->can_add ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" name="permissions[{{ $child->id }}][can_edit]" {{ $perm && $perm->can_edit ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" name="permissions[{{ $child->id }}][can_view]" {{ $perm && $perm->can_view ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" name="permissions[{{ $child->id }}][can_delete]" {{ $perm && $perm->can_delete ? 'checked' : '' }}></td>
+                                        </tr>
+                                    @endforeach
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#permissionForm').on('submit', function(e){
+        e.preventDefault();
+        if($('#permissionForm input[type="checkbox"]:checked').length === 0){
+            toastr.error('Please select at least one permission.');
+            return;
+        }
+        $.ajax({
+            url: '{{ route('super-admin.roles.permissions.update', $role->id) }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    toastr.error('Validation failed.');
+                } else {
+                    toastr.error('Unable to save permissions.');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -364,6 +364,7 @@ use App\Http\Controllers\Admin\AdvertisementController;
 use App\Http\Controllers\Admin\ProductBrandController;
 use App\Http\Controllers\Admin\UserAccountController;
 use App\Http\Controllers\Admin\RoleController;
+use App\Http\Controllers\Admin\RolePermissionController;
 use App\Http\Controllers\Admin\UsermanagementController;
 
 
@@ -469,6 +470,8 @@ Route::prefix('super-admin/roles')->name('super-admin.roles.')->group(function (
     Route::get('/{id}/edit', [RoleController::class, 'edit'])->name('edit');
     Route::put('/{id}', [RoleController::class, 'update'])->name('update');
     Route::delete('/{id}', [RoleController::class, 'destroy'])->name('destroy');
+    Route::get('/{id}/permissions', [RolePermissionController::class, 'edit'])->name('permissions.edit');
+    Route::post('/{id}/permissions', [RolePermissionController::class, 'update'])->name('permissions.update');
 });
 
 Route::prefix('super-admin/user-management')->name('super-admin.user-management.')->group(function () {


### PR DESCRIPTION
## Summary
- add modules and role_permission tables for hierarchical module permissions
- implement RolePermissionController and models to manage permissions via AJAX
- provide admin UI and route to assign module permissions per role with lock-icon button

## Testing
- `php artisan test` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68947439a8ec8327ac084dacdd17bf18