### PR TITLE
feat: add permission selection helpers

### DIFF
--- a/resources/views/ursbid-admin/roles/permissions.blade.php
+++ b/resources/views/ursbid-admin/roles/permissions.blade.php
@@ -27,37 +27,56 @@
                         <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    <th>Module/Submodule</th>
-                                    <th>Add</th>
-                                    <th>Edit</th>
-                                    <th>View</th>
-                                    <th>Delete</th>
+                                    <th>
+                                        <input type="checkbox" id="checkAll"> Module/Submodule
+                                    </th>
+                                    <th>
+                                        <input type="checkbox" class="column-check" data-perm="can_add"> Add
+                                    </th>
+                                    <th>
+                                        <input type="checkbox" class="column-check" data-perm="can_edit"> Edit
+                                    </th>
+                                    <th>
+                                        <input type="checkbox" class="column-check" data-perm="can_view"> View
+                                    </th>
+                                    <th>
+                                        <input type="checkbox" class="column-check" data-perm="can_delete"> Delete
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach($modules as $module)
                                     @if($module->children->isEmpty())
                                         @php $perm = $permissions[$module->id] ?? null; @endphp
-                                        <tr>
-                                            <td><strong>{{ $module->name }}</strong></td>
-                                            <td><input type="checkbox" value="1" name="permissions[{{ $module->id }}][can_add]" {{ $perm && $perm->can_add ? 'checked' : '' }}></td>
-                                            <td><input type="checkbox" value="1" name="permissions[{{ $module->id }}][can_edit]" {{ $perm && $perm->can_edit ? 'checked' : '' }}></td>
-                                            <td><input type="checkbox" value="1" name="permissions[{{ $module->id }}][can_view]" {{ $perm && $perm->can_view ? 'checked' : '' }}></td>
-                                            <td><input type="checkbox" value="1" name="permissions[{{ $module->id }}][can_delete]" {{ $perm && $perm->can_delete ? 'checked' : '' }}></td>
+                                        <tr data-module="{{ $module->id }}">
+                                            <td>
+                                                <input type="checkbox" class="row-check">
+                                                <strong>{{ $module->name }}</strong>
+                                            </td>
+                                            <td><input type="checkbox" class="permission-checkbox" data-perm="can_add" value="1" name="permissions[{{ $module->id }}][can_add]" {{ $perm && $perm->can_add ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" class="permission-checkbox" data-perm="can_edit" value="1" name="permissions[{{ $module->id }}][can_edit]" {{ $perm && $perm->can_edit ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" class="permission-checkbox" data-perm="can_view" value="1" name="permissions[{{ $module->id }}][can_view]" {{ $perm && $perm->can_view ? 'checked' : '' }}></td>
+                                            <td><input type="checkbox" class="permission-checkbox" data-perm="can_delete" value="1" name="permissions[{{ $module->id }}][can_delete]" {{ $perm && $perm->can_delete ? 'checked' : '' }}></td>
                                         </tr>
                                     @else
-                                        <tr>
-                                            <td><strong>{{ $module->name }}</strong></td>
+                                        <tr class="module-row" data-module="{{ $module->id }}">
+                                            <td>
+                                                <input type="checkbox" class="module-check" data-module="{{ $module->id }}">
+                                                <strong>{{ $module->name }}</strong>
+                                            </td>
                                             <td colspan="4"></td>
                                         </tr>
                                         @foreach($module->children as $child)
                                             @php $perm = $permissions[$child->id] ?? null; @endphp
-                                            <tr>
-                                                <td class="ps-4">{{ $child->name }}</td>
-                                                <td><input type="checkbox" value="1" name="permissions[{{ $child->id }}][can_add]" {{ $perm && $perm->can_add ? 'checked' : '' }}></td>
-                                                <td><input type="checkbox" value="1" name="permissions[{{ $child->id }}][can_edit]" {{ $perm && $perm->can_edit ? 'checked' : '' }}></td>
-                                                <td><input type="checkbox" value="1" name="permissions[{{ $child->id }}][can_view]" {{ $perm && $perm->can_view ? 'checked' : '' }}></td>
-                                                <td><input type="checkbox" value="1" name="permissions[{{ $child->id }}][can_delete]" {{ $perm && $perm->can_delete ? 'checked' : '' }}></td>
+                                            <tr data-parent="{{ $module->id }}">
+                                                <td class="ps-4">
+                                                    <input type="checkbox" class="row-check">
+                                                    {{ $child->name }}
+                                                </td>
+                                                <td><input type="checkbox" class="permission-checkbox" data-perm="can_add" value="1" name="permissions[{{ $child->id }}][can_add]" {{ $perm && $perm->can_add ? 'checked' : '' }}></td>
+                                                <td><input type="checkbox" class="permission-checkbox" data-perm="can_edit" value="1" name="permissions[{{ $child->id }}][can_edit]" {{ $perm && $perm->can_edit ? 'checked' : '' }}></td>
+                                                <td><input type="checkbox" class="permission-checkbox" data-perm="can_view" value="1" name="permissions[{{ $child->id }}][can_view]" {{ $perm && $perm->can_view ? 'checked' : '' }}></td>
+                                                <td><input type="checkbox" class="permission-checkbox" data-perm="can_delete" value="1" name="permissions[{{ $child->id }}][can_delete]" {{ $perm && $perm->can_delete ? 'checked' : '' }}></td>
                                             </tr>
                                         @endforeach
                                     @endif
@@ -78,9 +97,77 @@
 @push('scripts')
 <script>
 $(function(){
+    function updateRowChecks(){
+        $('#permissionForm tbody tr').each(function(){
+            var row = $(this);
+            var boxes = row.find('.permission-checkbox');
+            if(boxes.length){
+                var allChecked = boxes.length === boxes.filter(':checked').length;
+                row.find('.row-check').prop('checked', allChecked);
+            }
+        });
+    }
+
+    function updateColumnChecks(){
+        $('.column-check').each(function(){
+            var perm = $(this).data('perm');
+            var boxes = $('.permission-checkbox[data-perm="'+perm+'"]');
+            var allChecked = boxes.length === boxes.filter(':checked').length;
+            $(this).prop('checked', allChecked);
+        });
+        var allBoxes = $('.permission-checkbox');
+        var allChecked = allBoxes.length === allBoxes.filter(':checked').length;
+        $('#checkAll').prop('checked', allChecked);
+    }
+
+    function updateModuleChecks(){
+        $('.module-check').each(function(){
+            var moduleId = $(this).data('module');
+            var boxes = $('tr[data-parent="'+moduleId+'"] .permission-checkbox');
+            var allChecked = boxes.length && boxes.length === boxes.filter(':checked').length;
+            $(this).prop('checked', allChecked);
+        });
+    }
+
+    updateRowChecks();
+    updateColumnChecks();
+    updateModuleChecks();
+
+    $('#checkAll').on('change', function(){
+        var checked = this.checked;
+        $('.column-check, .row-check, .module-check, .permission-checkbox').prop('checked', checked);
+    });
+
+    $('.column-check').on('change', function(){
+        var perm = $(this).data('perm');
+        $('.permission-checkbox[data-perm="'+perm+'"]').prop('checked', this.checked);
+        updateRowChecks();
+        updateModuleChecks();
+        updateColumnChecks();
+    });
+
+    $('.row-check').on('change', function(){
+        var row = $(this).closest('tr');
+        row.find('.permission-checkbox').prop('checked', this.checked);
+        updateColumnChecks();
+        updateModuleChecks();
+    });
+
+    $('.module-check').on('change', function(){
+        var moduleId = $(this).data('module');
+        $('tr[data-parent="'+moduleId+'"] .permission-checkbox, tr[data-parent="'+moduleId+'"] .row-check').prop('checked', this.checked);
+        updateColumnChecks();
+    });
+
+    $('.permission-checkbox').on('change', function(){
+        updateRowChecks();
+        updateColumnChecks();
+        updateModuleChecks();
+    });
+
     $('#permissionForm').on('submit', function(e){
         e.preventDefault();
-        if($('#permissionForm input[type="checkbox"]:checked').length === 0){
+        if($('#permissionForm .permission-checkbox:checked').length === 0){
             toastr.error('Please select at least one permission.');
             return;
         }


### PR DESCRIPTION
## Summary
- add checkboxes to toggle permissions globally, per module, and per column
- sync checkboxes with client-side JavaScript and validate with AJAX

## Testing
- `composer install` (fails: nette/schema v1.2.5 requires php 7.1 - 8.3)
- `php artisan test` (fails: Failed opening required 'vendor/autoload.php')
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68947f65cf048327bf5506a60c55f2c2