### PR TITLE
chore: group roles and user management

### DIFF
--- a/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/sidebar.blade.php
@@ -142,21 +142,28 @@
             </li>
 
             <li class="nav-item">
-                <a class="nav-link {{ request()->is('super-admin/roles*') ? 'active' : '' }}" href="{{ route('super-admin.roles.index') }}">
-                    <span class="nav-icon">
-                        <i class="ri-shield-user-line"></i>
-                    </span>
-                    <span class="nav-text">Roles</span>
-                </a>
-            </li>
-
-            <li class="nav-item">
-                <a class="nav-link {{ request()->is('super-admin/user-management*') ? 'active' : '' }}" href="{{ route('super-admin.user-management.index') }}">
+                <a class="nav-link menu-arrow {{ request()->is('super-admin/roles*') || request()->is('super-admin/user-management*') ? 'active' : '' }}"
+                   href="#sidebarUserRoles" data-bs-toggle="collapse" role="button"
+                   aria-expanded="{{ request()->is('super-admin/roles*') || request()->is('super-admin/user-management*') ? 'true' : 'false' }}"
+                   aria-controls="sidebarUserRoles">
                     <span class="nav-icon">
                         <i class="ri-user-settings-line"></i>
                     </span>
-                    <span class="nav-text">User Management</span>
+                    <span class="nav-text">Roles &amp; User Management</span>
                 </a>
+                <div class="collapse {{ request()->is('super-admin/roles*') || request()->is('super-admin/user-management*') ? 'show' : '' }}"
+                     id="sidebarUserRoles">
+                    <ul class="nav sub-navbar-nav">
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/roles*') ? 'active' : '' }}"
+                               href="{{ route('super-admin.roles.index') }}">Roles Management</a>
+                        </li>
+                        <li class="sub-nav-item">
+                            <a class="sub-nav-link {{ request()->is('super-admin/user-management*') ? 'active' : '' }}"
+                               href="{{ route('super-admin.user-management.index') }}">User Management</a>
+                        </li>
+                    </ul>
+                </div>
             </li>
 
             <li class="nav-item">


### PR DESCRIPTION
## Summary
- group Roles and User Management under a single sidebar menu with separate sub-links

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_6894835159b4832782e28cde814c3c1c