### PR TITLE
Add admin dashboard stats cards

### DIFF
--- a/app/Http/Controllers/Admin/AdminDashboardController.php
+++ b/app/Http/Controllers/Admin/AdminDashboardController.php
@@ -3,7 +3,11 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Models\Category;
+use App\Models\SubCategory;
+use App\Models\Product;
+use App\Models\UserAccount;
+use Carbon\Carbon;
 
 class AdminDashboardController extends Controller
 {
@@ -14,14 +18,18 @@ class AdminDashboardController extends Controller
      */
     public function index()
     {
-       
         $stats = [
-            'monthlyEarnings' => 3548.09,
-            'earningsGrowth' => 67435.00,
-            'conversionRate' => 78.8,
-            'profitMargin' => 34.00
+            'categories'   => Category::count(),
+            'subCategories'=> SubCategory::count(),
+            'products'     => Product::count(),
+            'vendors'      => UserAccount::where('user_type', 'vendor')->count(),
+            'buyers'       => UserAccount::where('user_type', 'buyer')->count(),
+            'contractors'  => UserAccount::where('user_type', 'contractor')->count(),
+            'clients'      => UserAccount::where('user_type', 'client')->count(),
         ];
 
-        return view('ursbid-admin.dashboard', compact('stats'));
+        $currentDate = Carbon::now()->format('d-m-Y');
+
+        return view('ursbid-admin.dashboard', compact('stats', 'currentDate'));
     }
 }

--- a/resources/views/ursbid-admin/dashboard.blade.php
+++ b/resources/views/ursbid-admin/dashboard.blade.php
@@ -17,16 +17,83 @@
     <!-- End Page Title -->
 
     <div class="row">
-        <div class="col-md-12 col-xl-12">
-            <div class="container-fluid">
-            <div class="card">
-                <div class="card-content-stretch p-4">                    
-                    <h2>Super Admin Dashboard <br> Hello, URSBID, Welcome to Super Admin Dashboard</h2>
+        <div class="col-md-12">
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h2 class="mb-1">Super Admin Dashboard</h2>
+                    <p class="mb-0">Hello, URSBID, Welcome to Super Admin Dashboard</p>
                 </div>
             </div>
         </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Category</h5>
+                                    <h2 class="mb-0">{{ $stats['categories'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Sub Category</h5>
+                                    <h2 class="mb-0">{{ $stats['subCategories'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Product</h5>
+                                    <h2 class="mb-0">{{ $stats['products'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Vendor</h5>
+                                    <h2 class="mb-0">{{ $stats['vendors'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Buyer</h5>
+                                    <h2 class="mb-0">{{ $stats['buyers'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Contractor</h5>
+                                    <h2 class="mb-0">{{ $stats['contractors'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-xl-3">
+                            <div class="card mb-0 text-center">
+                                <div class="card-body">
+                                    <h5 class="mb-2">Total Client</h5>
+                                    <h2 class="mb-0">{{ $stats['clients'] }}</h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="text-end mt-3 mb-0"><small>As of {{ $currentDate }}</small></p>
+                </div>
+            </div>
         </div>
-        <!-- Add other cards similarly -->
     </div>
 </div>
 @endsection
+


### PR DESCRIPTION
## Summary
- show category, product, and account totals on admin dashboard
- display dashboard stats card grid with current date

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3, current php is 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_6894883f3b588327a0d92303d33fffeb