### PR TITLE
Add profile editing and password change options to admin topbar

### DIFF
--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rules\Password as PasswordRule;
+use Carbon\Carbon;
+
+class ProfileController extends Controller
+{
+    public function edit()
+    {
+        $user = Auth::user();
+        return view('ursbid-admin.profile.edit', compact('user'));
+    }
+
+    public function update(Request $request)
+    {
+        $user = Auth::user();
+
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email,' . $user->id,
+            'address' => 'nullable|string',
+            'created_at' => 'required|date_format:d-m-Y',
+        ]);
+
+        $user->name = $request->name;
+        $user->email = $request->email;
+        $user->address = $request->address;
+        $user->created_at = Carbon::createFromFormat('d-m-Y', $request->created_at);
+        $user->save();
+
+        return response()->json(['message' => 'Profile updated successfully.']);
+    }
+
+    public function editPassword()
+    {
+        return view('ursbid-admin.profile.change-password');
+    }
+
+    public function updatePassword(Request $request)
+    {
+        $user = Auth::user();
+
+        $request->validate([
+            'current_password' => 'required',
+            'password' => ['required', 'confirmed', PasswordRule::min(6)],
+        ]);
+
+        if (!Hash::check($request->current_password, $user->password)) {
+            return response()->json([
+                'errors' => ['current_password' => ['Current password is incorrect.']]
+            ], 422);
+        }
+
+        $user->password = Hash::make($request->password);
+        $user->save();
+
+        return response()->json(['message' => 'Password updated successfully.']);
+    }
+}

--- a/resources/views/ursbid-admin/layouts/partials/topbar.blade.php
+++ b/resources/views/ursbid-admin/layouts/partials/topbar.blade.php
@@ -129,10 +129,13 @@
                      </a>
                      <div class="dropdown-menu dropdown-menu-end">
                           <!-- item-->
-                          <h6 class="dropdown-header">Welcome Gaston!</h6>
+                          <h6 class="dropdown-header">Welcome {{ auth()->user()->name }}!</h6>
                   
-                          <a class="dropdown-item" href="pages-calendar.html">
-                               <iconify-icon icon="solar:calendar-broken" class="align-middle me-2 fs-18"></iconify-icon><span class="align-middle">Profile </span>
+                          <a class="dropdown-item" href="{{ route('super-admin.profile.edit') }}">
+                               <iconify-icon icon="solar:user-circle-line-duotone" class="align-middle me-2 fs-18"></iconify-icon><span class="align-middle">Edit Profile</span>
+                          </a>
+                          <a class="dropdown-item" href="{{ route('super-admin.password.edit') }}">
+                               <iconify-icon icon="solar:lock-password-outline" class="align-middle me-2 fs-18"></iconify-icon><span class="align-middle">Change Password</span>
                           </a>
 
                           <div class="dropdown-divider my-1"></div>

--- a/resources/views/ursbid-admin/profile/change-password.blade.php
+++ b/resources/views/ursbid-admin/profile/change-password.blade.php
@@ -1,0 +1,70 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Change Password')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Change Password</h4>
+                </div>
+                <form id="passwordForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Current Password</label>
+                            <input type="password" name="current_password" class="form-control" required>
+                            <div class="invalid-feedback" data-field="current_password"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">New Password</label>
+                            <input type="password" name="password" class="form-control" required>
+                            <div class="invalid-feedback" data-field="password"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Confirm Password</label>
+                            <input type="password" name="password_confirmation" class="form-control" required>
+                            <div class="invalid-feedback" data-field="password_confirmation"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#passwordForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        $.ajax({
+            url: '{{ route('super-admin.password.update') }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+                $('#passwordForm')[0].reset();
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for (let field in errors) {
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Update failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/resources/views/ursbid-admin/profile/edit.blade.php
+++ b/resources/views/ursbid-admin/profile/edit.blade.php
@@ -1,0 +1,80 @@
+@extends('ursbid-admin.layouts.app')
+@section('title', 'Edit Profile')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header border-bottom">
+                    <h4 class="card-title mb-0">Edit Profile</h4>
+                </div>
+                <form id="profileForm">
+                    @csrf
+                    @method('PUT')
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Name</label>
+                            <input type="text" name="name" class="form-control" value="{{ $user->name }}" required>
+                            <div class="invalid-feedback" data-field="name"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" value="{{ $user->email }}" required>
+                            <div class="invalid-feedback" data-field="email"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Address</label>
+                            <input type="text" name="address" class="form-control" value="{{ $user->address }}">
+                            <div class="invalid-feedback" data-field="address"></div>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Joining Date</label>
+                            <input type="text" name="created_at" class="form-control" value="{{ optional($user->created_at)->format('d-m-Y') }}" placeholder="dd-mm-yyyy" required>
+                            <div class="invalid-feedback" data-field="created_at"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-primary">Update</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+$(function(){
+    $('#profileForm').on('submit', function(e){
+        e.preventDefault();
+        $('.invalid-feedback').text('');
+        const datePattern = /^\\d{2}-\\d{2}-\\d{4}$/;
+        const joinDate = $('input[name="created_at"]').val();
+        if(!datePattern.test(joinDate)){
+            $('[data-field="created_at"]').text('Date must be in dd-mm-yyyy format.');
+            return;
+        }
+        $.ajax({
+            url: '{{ route('super-admin.profile.update') }}',
+            type: 'POST',
+            data: $(this).serialize(),
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(xhr){
+                if(xhr.status === 422){
+                    let errors = xhr.responseJSON.errors;
+                    for (let field in errors) {
+                        $('[data-field="'+field+'"]').text(errors[field][0]);
+                    }
+                }else{
+                    toastr.error('Update failed');
+                }
+            }
+        });
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -360,11 +360,17 @@ use App\Http\Controllers\Admin\UserAccountController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\RolePermissionController;
 use App\Http\Controllers\Admin\UsermanagementController;
+use App\Http\Controllers\Admin\ProfileController;
 
 
 Route::get('super-admin', [AuthController::class, 'showLoginForm'])->name('admin.login');
 Route::post('super-admin/login', [AuthController::class, 'login'])->name('admin.login.submit');
 Route::any('super-admin/logout', [AuthController::class, 'logout'])->name('admin.logout');
+
+Route::get('super-admin/profile', [ProfileController::class, 'edit'])->name('super-admin.profile.edit');
+Route::post('super-admin/profile', [ProfileController::class, 'update'])->name('super-admin.profile.update');
+Route::get('super-admin/change-password', [ProfileController::class, 'editPassword'])->name('super-admin.password.edit');
+Route::post('super-admin/change-password', [ProfileController::class, 'updatePassword'])->name('super-admin.password.update');
 
 Route::prefix('super-admin')->group(function () {
     Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('super-admin.dashboard');


### PR DESCRIPTION
## Summary
- add admin profile controller with update and password change methods
- create profile and password views with client-side and AJAX validation
- expose profile/password routes and link them in the topbar

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894c7e14808832788f3e9313acb23c7