### PR TITLE
fix: correct HTTP method for profile update

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -368,7 +368,8 @@ Route::post('super-admin/login', [AuthController::class, 'login'])->name('admin.
 Route::any('super-admin/logout', [AuthController::class, 'logout'])->name('admin.logout');
 
 Route::get('super-admin/profile', [ProfileController::class, 'edit'])->name('super-admin.profile.edit');
-Route::post('super-admin/profile', [ProfileController::class, 'update'])->name('super-admin.profile.update');
+// Use PUT to properly handle method spoofing from AJAX form submissions
+Route::put('super-admin/profile', [ProfileController::class, 'update'])->name('super-admin.profile.update');
 Route::get('super-admin/change-password', [ProfileController::class, 'editPassword'])->name('super-admin.password.edit');
 Route::post('super-admin/change-password', [ProfileController::class, 'updatePassword'])->name('super-admin.password.update');
 


### PR DESCRIPTION
## Summary
- Fix profile update route to use PUT for AJAX submissions

## Testing
- `composer install` *(fails: nette/schema requires PHP <=8.3; current PHP is 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_689591376434832789e461b020791bb7