### PR TITLE
Show only sub-users in user list

### DIFF
--- a/app/Http/Controllers/Admin/UsermanagementController.php
+++ b/app/Http/Controllers/Admin/UsermanagementController.php
@@ -18,7 +18,10 @@ class UsermanagementController extends Controller
 
     public function list()
     {
-        $users = User::with('roles')->orderByDesc('id')->get();
+        $users = User::with('roles')
+            ->where('parent_id', '!=', 0)
+            ->orderByDesc('id')
+            ->get();
         $html = view('ursbid-admin.user_management.partials.table', [
             'users' => $users,
         ])->render();


### PR DESCRIPTION
## Summary
- filter user management list to show only accounts with a parent user

## Testing
- `composer install` (fails: nette/schema v1.2.5 requires php 7.1 - 8.3)
- `php artisan test` (fails: require(/workspace/ursbid-work/vendor/autoload.php): Failed to open stream)


------
https://chatgpt.com/codex/tasks/task_e_6896347462d48327a3231bccccfa47e8