### PR TITLE
Add custom 403 error page for unauthorized access

### DIFF
--- a/app/Http/Middleware/ModulePermissionMiddleware.php
+++ b/app/Http/Middleware/ModulePermissionMiddleware.php
@@ -11,7 +11,7 @@ class ModulePermissionMiddleware
     {
         $user = Auth::user();
         if (!$user || !$user->hasModulePermission($moduleSlug, $permission)) {
-            abort(403);
+            abort(403, 'You have no permission to access this page.');
         }
         return $next($request);
     }

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Unauthorized</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-5">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h4 class="text-danger">You have no permission to access this page.</h4>
+                    <p class="mt-3">{{ now()->format('d-m-Y') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show a friendly message when module permission fails
- add a Bootstrap-styled 403 error view with date display

## Testing
- `composer install --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68964094afd4832788509476f2b5e350