### PR TITLE
Align admin controllers with new category tables

### DIFF
--- a/app/Http/Controllers/Admin/AdvertisementController.php
+++ b/app/Http/Controllers/Admin/AdvertisementController.php
@@ -12,8 +12,8 @@ class AdvertisementController extends Controller
 {
     public function index()
     {
-        $advertisements = Advertisement::leftJoin('category', 'advertisements.category_id', '=', 'category.id')
-            ->select('advertisements.*', 'category.title as category_title')
+        $advertisements = Advertisement::leftJoin('categories', 'advertisements.category_id', '=', 'categories.id')
+            ->select('advertisements.*', 'categories.name as category_name')
             ->orderByDesc('advertisements.id')
             ->paginate(10);
 
@@ -22,7 +22,7 @@ class AdvertisementController extends Controller
 
     public function create()
     {
-        $categories = Category::where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
         return view('ursbid-admin.advertisement.create', compact('categories'));
     }
 
@@ -62,7 +62,7 @@ class AdvertisementController extends Controller
     public function edit($id)
     {
         $advertisement = Advertisement::findOrFail($id);
-        $categories = Category::where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
         return view('ursbid-admin.advertisement.edit', compact('advertisement', 'categories'));
     }
 

--- a/app/Http/Controllers/Admin/ProductBrandController.php
+++ b/app/Http/Controllers/Admin/ProductBrandController.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\ProductBrand;
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\SubCategory;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
@@ -15,10 +15,10 @@ class ProductBrandController extends Controller
 {
     public function index()
     {
-        $brands = ProductBrand::leftJoin('category', 'product_brands.category_id', '=', 'category.id')
-            ->leftJoin('sub', 'product_brands.sub_category_id', '=', 'sub.id')
+        $brands = ProductBrand::leftJoin('categories', 'product_brands.category_id', '=', 'categories.id')
+            ->leftJoin('sub_categories', 'product_brands.sub_category_id', '=', 'sub_categories.id')
             ->leftJoin('product', 'product_brands.product_id', '=', 'product.id')
-            ->select('product_brands.*', 'category.title as category_title', 'sub.title as sub_title', 'product.title as product_title')
+            ->select('product_brands.*', 'categories.name as category_name', 'sub_categories.name as sub_name', 'product.title as product_title')
             ->orderByDesc('product_brands.id')
             ->paginate(10);
 
@@ -27,8 +27,8 @@ class ProductBrandController extends Controller
 
     public function create()
     {
-        $categories = Category::where('status', 1)->orderBy('title')->get();
-        $subs = DB::table('sub')->where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
+        $subs = SubCategory::where('status', 1)->orderBy('name')->get();
         $products = Product::where('status', 1)->orderBy('title')->get();
         return view('ursbid-admin.product_brands.create', compact('categories', 'subs', 'products'));
     }
@@ -66,8 +66,8 @@ class ProductBrandController extends Controller
     public function edit($id)
     {
         $brand = ProductBrand::findOrFail($id);
-        $categories = Category::where('status', 1)->orderBy('title')->get();
-        $subs = DB::table('sub')->where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
+        $subs = SubCategory::where('status', 1)->orderBy('name')->get();
         $products = Product::where('status', 1)->orderBy('title')->get();
         return view('ursbid-admin.product_brands.edit', compact('brand', 'categories', 'subs', 'products'));
     }

--- a/app/Http/Controllers/Admin/UnitController.php
+++ b/app/Http/Controllers/Admin/UnitController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Category;
 use App\Models\Unit;
+use App\Models\SubCategory;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
@@ -14,9 +14,9 @@ class UnitController extends Controller
 {
     public function index()
     {
-        $units = Unit::leftJoin('category', 'unit.cat_id', '=', 'category.id')
-            ->leftJoin('sub', 'unit.sub_id', '=', 'sub.id')
-            ->select('unit.*', 'category.title as category_title', 'sub.title as sub_title')
+        $units = Unit::leftJoin('categories', 'unit.cat_id', '=', 'categories.id')
+            ->leftJoin('sub_categories', 'unit.sub_id', '=', 'sub_categories.id')
+            ->select('unit.*', 'categories.name as category_name', 'sub_categories.name as sub_name')
             ->orderByDesc('unit.id')
             ->paginate(10);
 
@@ -25,8 +25,8 @@ class UnitController extends Controller
 
     public function create()
     {
-        $categories = Category::where('status', 1)->orderBy('title')->get();
-        $subs = DB::table('sub')->where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
+        $subs = SubCategory::where('status', 1)->orderBy('name')->get();
         return view('ursbid-admin.unit.create', compact('categories', 'subs'));
     }
 
@@ -61,8 +61,8 @@ class UnitController extends Controller
     public function edit($id)
     {
         $unit = Unit::findOrFail($id);
-        $categories = Category::where('status', 1)->orderBy('title')->get();
-        $subs = DB::table('sub')->where('status', 1)->orderBy('title')->get();
+        $categories = Category::where('status', 1)->orderBy('name')->get();
+        $subs = SubCategory::where('status', 1)->orderBy('name')->get();
         return view('ursbid-admin.unit.edit', compact('unit', 'categories', 'subs'));
     }
 

--- a/resources/views/ursbid-admin/advertisement/create.blade.php
+++ b/resources/views/ursbid-admin/advertisement/create.blade.php
@@ -28,7 +28,7 @@
                                 <select name="category_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}">{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}">{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/advertisement/edit.blade.php
+++ b/resources/views/ursbid-admin/advertisement/edit.blade.php
@@ -29,7 +29,7 @@
                                 <select name="category_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}" {{ $advertisement->category_id == $category->id ? 'selected' : '' }}>{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}" {{ $advertisement->category_id == $category->id ? 'selected' : '' }}>{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/advertisement/list.blade.php
+++ b/resources/views/ursbid-admin/advertisement/list.blade.php
@@ -88,7 +88,7 @@
                             @forelse($advertisements as $ad)
                             <tr id="row-{{ $ad->id }}">
                                 <td>{{ $advertisements->firstItem() + $loop->index }}</td>
-                                <td>{{ $ad->category_title }}</td>
+                                <td>{{ $ad->category_name }}</td>
                                 <td>
                                     @if($ad->image)
                                         <img src="{{ asset($ad->image) }}" alt="image" width="80">

--- a/resources/views/ursbid-admin/product_brands/create.blade.php
+++ b/resources/views/ursbid-admin/product_brands/create.blade.php
@@ -28,7 +28,7 @@
                                 <select name="category_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}">{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}">{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>
@@ -41,7 +41,7 @@
                                 <select name="sub_category_id" class="form-control">
                                     <option value="">Select Sub Category</option>
                                     @foreach($subs as $sub)
-                                        <option value="{{ $sub->id }}">{{ $sub->title }}</option>
+                                        <option value="{{ $sub->id }}">{{ $sub->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/product_brands/edit.blade.php
+++ b/resources/views/ursbid-admin/product_brands/edit.blade.php
@@ -29,7 +29,7 @@
                                 <select name="category_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}" {{ $category->id == $brand->category_id ? 'selected' : '' }}>{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}" {{ $category->id == $brand->category_id ? 'selected' : '' }}>{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>
@@ -42,7 +42,7 @@
                                 <select name="sub_category_id" class="form-control">
                                     <option value="">Select Sub Category</option>
                                     @foreach($subs as $sub)
-                                        <option value="{{ $sub->id }}" {{ $sub->id == $brand->sub_category_id ? 'selected' : '' }}>{{ $sub->title }}</option>
+                                        <option value="{{ $sub->id }}" {{ $sub->id == $brand->sub_category_id ? 'selected' : '' }}>{{ $sub->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/product_brands/list.blade.php
+++ b/resources/views/ursbid-admin/product_brands/list.blade.php
@@ -90,8 +90,8 @@
                             @forelse($brands as $brand)
                             <tr id="row-{{ $brand->id }}">
                                 <td>{{ $brands->firstItem() + $loop->index }}</td>
-                                <td>{{ $brand->category_title }}</td>
-                                <td>{{ $brand->sub_title }}</td>
+                                <td>{{ $brand->category_name }}</td>
+                                <td>{{ $brand->sub_name }}</td>
                                 <td>{{ $brand->product_title }}</td>
                                 <td>{{ $brand->brand_name }}</td>
                                 <td>{{ \Carbon\Carbon::parse($brand->created_at)->format('d-m-Y') }}</td>

--- a/resources/views/ursbid-admin/unit/create.blade.php
+++ b/resources/views/ursbid-admin/unit/create.blade.php
@@ -28,7 +28,7 @@
                                 <select name="cat_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}">{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}">{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>
@@ -41,7 +41,7 @@
                                 <select name="sub_id" class="form-control">
                                     <option value="">Select Sub Category</option>
                                     @foreach($subs as $sub)
-                                        <option value="{{ $sub->id }}">{{ $sub->title }}</option>
+                                        <option value="{{ $sub->id }}">{{ $sub->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/unit/edit.blade.php
+++ b/resources/views/ursbid-admin/unit/edit.blade.php
@@ -29,7 +29,7 @@
                                 <select name="cat_id" class="form-control">
                                     <option value="">Select Category</option>
                                     @foreach($categories as $category)
-                                        <option value="{{ $category->id }}" {{ $unit->cat_id == $category->id ? 'selected' : '' }}>{{ $category->title }}</option>
+                                        <option value="{{ $category->id }}" {{ $unit->cat_id == $category->id ? 'selected' : '' }}>{{ $category->name }}</option>
                                     @endforeach
                                 </select>
                             </div>
@@ -42,7 +42,7 @@
                                 <select name="sub_id" class="form-control">
                                     <option value="">Select Sub Category</option>
                                     @foreach($subs as $sub)
-                                        <option value="{{ $sub->id }}" {{ $unit->sub_id == $sub->id ? 'selected' : '' }}>{{ $sub->title }}</option>
+                                        <option value="{{ $sub->id }}" {{ $unit->sub_id == $sub->id ? 'selected' : '' }}>{{ $sub->name }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/ursbid-admin/unit/list.blade.php
+++ b/resources/views/ursbid-admin/unit/list.blade.php
@@ -89,8 +89,8 @@
                             @forelse($units as $unit)
                             <tr id="row-{{ $unit->id }}">
                                 <td>{{ $units->firstItem() + $loop->index }}</td>
-                                <td>{{ $unit->category_title }}</td>
-                                <td>{{ $unit->sub_title }}</td>
+                                <td>{{ $unit->category_name }}</td>
+                                <td>{{ $unit->sub_name }}</td>
                                 <td>{{ $unit->title }}</td>
                                 <td>{{ \Carbon\Carbon::parse($unit->created_at)->format('d-m-Y') }}</td>
                                 <td>


### PR DESCRIPTION
## Summary
- Switch admin product brand, unit, and advertisement controllers to join `categories` and `sub_categories`
- Update admin views to reference category and subcategory `name` fields

## Testing
- `composer install --no-progress --no-interaction` *(fails: lock file packages require PHP <=8.3)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896c925e4a08327b7047e8b3fb2c3ff