### PR TITLE
Add consistent delete confirmation modal across admin lists

### DIFF
--- a/resources/views/ursbid-admin/blogs/list.blade.php
+++ b/resources/views/ursbid-admin/blogs/list.blade.php
@@ -107,7 +107,7 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $blog->post_date ?? '' }}</td>
+                                <td>{{ $blog->post_date ? \Carbon\Carbon::parse($blog->post_date)->format('d-m-Y') : '' }}</td>
                                 <td>
                                     @if($blog->status == 1)
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>

--- a/resources/views/ursbid-admin/on_page_seo/list.blade.php
+++ b/resources/views/ursbid-admin/on_page_seo/list.blade.php
@@ -102,23 +102,60 @@
         </div>
     </div>
 </div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content border-0 shadow-lg">
+      <div class="modal-header bg-danger text-white rounded-top">
+        <h5 class="modal-title" id="deleteConfirmLabel">
+            <i class="ri-error-warning-line me-2"></i> Confirm Deletion
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <div class="mb-3">
+          <i class="ri-alert-line text-danger" style="font-size: 40px;"></i>
+        </div>
+        <p class="mb-1 fs-5 fw-semibold">Are you sure you want to delete this item?</p>
+        <p class="text-muted">This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer justify-content-center border-0">
+        <button type="button" class="btn btn-light px-4" data-bs-dismiss="modal">
+            <i class="ri-close-line me-1"></i> Cancel
+        </button>
+        <button type="button" class="btn btn-danger px-4" id="confirmDeleteBtn">
+            <i class="ri-delete-bin-line me-1"></i> Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
 @endsection
+
 @push('scripts')
 <script>
+let deleteId = null;
+let deleteUrl = null;
 $(function(){
-    $('.deleteBtn').on('click',function(){
-        if(!confirm('Are you sure want to delete?')) return;
-        let id = $(this).data('id');
-        let url = $(this).data('url');
+    $('.deleteBtn').on('click', function(){
+        deleteId = $(this).data('id');
+        deleteUrl = $(this).data('url');
+        $('#deleteConfirmModal').modal('show');
+    });
+
+    $('#confirmDeleteBtn').on('click', function(){
         $.ajax({
-            url:url,
-            type:'DELETE',
-            data:{ _token:'{{ csrf_token() }}' },
-            success:function(res){
+            url: deleteUrl,
+            type: 'DELETE',
+            data: { _token: '{{ csrf_token() }}' },
+            success: function(res){
+                $('#deleteConfirmModal').modal('hide');
                 toastr.success(res.message);
-                $('#row-'+id).remove();
+                $('#row-'+deleteId).remove();
             },
-            error:function(){
+            error: function(){
+                $('#deleteConfirmModal').modal('hide');
                 toastr.error('Unable to delete record');
             }
         });

--- a/resources/views/ursbid-admin/youtube_links/list.blade.php
+++ b/resources/views/ursbid-admin/youtube_links/list.blade.php
@@ -17,7 +17,7 @@
     <!-- ========== Page Title End ========== -->
 
     <div class="row">
-        <div class="col-xl-12">
+        <div class="col-md-12">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center border-bottom">
                     <div>


### PR DESCRIPTION
## Summary
- standardize Youtube links list layout to use col-md-12 card container
- ensure blog post dates render in dd-mm-yyyy format
- replace On Page SEO list's simple confirm with reusable AJAX delete confirmation modal

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_689a18a90d4c8327bd1b8c9e634156dd