### PR TITLE
Remove post date from blog list

### DIFF
--- a/resources/views/ursbid-admin/blogs/list.blade.php
+++ b/resources/views/ursbid-admin/blogs/list.blade.php
@@ -88,7 +88,6 @@
                             <tr>
                                 <th>S.No</th>
                                 <th>Blog Title</th>
-                                <th>Post Date</th>
                                 <th>Status</th>
                                 <th>Action</th>
                             </tr>
@@ -107,7 +106,6 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $blog->post_date ? \Carbon\Carbon::parse($blog->post_date)->format('d-m-Y') : '' }}</td>
                                 <td>
                                     @if($blog->status == 1)
                                         <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
@@ -131,7 +129,7 @@
                             </tr>
                             @empty
                             <tr>
-                                <td colspan="5" class="text-center">No blogs found.</td>
+                                <td colspan="4" class="text-center">No blogs found.</td>
                             </tr>
                             @endforelse
                         </tbody>


### PR DESCRIPTION
## Summary
- drop post date column from admin blog table

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_689a1b59826c8327a6ebfdeb788e60c6