### PR TITLE
Add modal delete confirmations for category and sub-category lists

### DIFF
--- a/resources/views/ursbid-admin/category/list.blade.php
+++ b/resources/views/ursbid-admin/category/list.blade.php
@@ -71,7 +71,7 @@
                                         </a>
                                         @endif
                                         @if(auth()->user()->hasModulePermission('categories','can_delete'))
-                                        <button type="button" data-id="{{ $category->id }}" class="btn btn-soft-danger btn-sm deleteBtn">
+                                        <button type="button" data-id="{{ $category->id }}" data-url="{{ route('super-admin.categories.destroy', $category->id) }}" class="btn btn-soft-danger btn-sm deleteBtn">
                                             <iconify-icon icon="solar:trash-bin-minimalistic-2-broken" class="align-middle fs-18"></iconify-icon>
                                         </button>
                                         @endif
@@ -90,27 +90,64 @@
                 <div class="card-footer">
                     {{ $categories->links() }}
                 </div>
-            </div>
-        </div>
     </div>
+</div>
+</div>
+</div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content border-0 shadow-lg">
+      <div class="modal-header bg-danger text-white rounded-top">
+        <h5 class="modal-title" id="deleteConfirmLabel">
+            <i class="ri-error-warning-line me-2"></i> Confirm Deletion
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <div class="mb-3">
+          <i class="ri-alert-line text-danger" style="font-size: 40px;"></i>
+        </div>
+        <p class="mb-1 fs-5 fw-semibold">Are you sure you want to delete this item?</p>
+        <p class="text-muted">This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer justify-content-center border-0">
+        <button type="button" class="btn btn-light px-4" data-bs-dismiss="modal">
+            <i class="ri-close-line me-1"></i> Cancel
+        </button>
+        <button type="button" class="btn btn-danger px-4" id="confirmDeleteBtn">
+            <i class="ri-delete-bin-line me-1"></i> Delete
+        </button>
+      </div>
+    </div>
+  </div>
 </div>
 @endsection
 
 @push('scripts')
 <script>
+let deleteId = null;
+let deleteUrl = null;
 $(function(){
     $('.deleteBtn').on('click', function(){
-        if(!confirm('Are you sure want to delete?')) return;
-        var id = $(this).data('id');
+        deleteId = $(this).data('id');
+        deleteUrl = $(this).data('url');
+        $('#deleteConfirmModal').modal('show');
+    });
+
+    $('#confirmDeleteBtn').on('click', function(){
         $.ajax({
-            url: '/super-admin/categories/'+id,
+            url: deleteUrl,
             type: 'DELETE',
             data: { _token: '{{ csrf_token() }}' },
             success: function(res){
+                $('#deleteConfirmModal').modal('hide');
                 toastr.success(res.message);
-                $('#row-'+id).remove();
+                $('#row-'+deleteId).remove();
             },
             error: function(){
+                $('#deleteConfirmModal').modal('hide');
                 toastr.error('Unable to delete record');
             }
         });

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -193,21 +193,65 @@
   </div>
 </div>
 
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content border-0 shadow-lg">
+      <div class="modal-header bg-danger text-white rounded-top">
+        <h5 class="modal-title" id="deleteConfirmLabel">
+          <i class="ri-error-warning-line me-2"></i> Confirm Deletion
+        </h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <div class="mb-3">
+          <i class="ri-alert-line text-danger" style="font-size: 40px;"></i>
+        </div>
+        <p class="mb-1 fs-5 fw-semibold">Are you sure you want to delete this item?</p>
+        <p class="text-muted">This action cannot be undone.</p>
+      </div>
+      <div class="modal-footer justify-content-center border-0">
+        <button type="button" class="btn btn-light px-4" data-bs-dismiss="modal">
+          <i class="ri-close-line me-1"></i> Cancel
+        </button>
+        <button type="button" class="btn btn-danger px-4" id="confirmDeleteBtn">
+          <i class="ri-delete-bin-line me-1"></i> Delete
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
 @endsection
 
 @push('scripts')
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 <script>
 (function(){
+  let deleteId = null;
+  let deleteUrl = null;
+
   // Delete
   $(document).on('click', '.deleteBtn', function(){
-    if(!confirm('Are you sure want to delete?')) return;
-    let url = $(this).data('url');
+    deleteId = $(this).data('id');
+    deleteUrl = $(this).data('url');
+    $('#deleteConfirmModal').modal('show');
+  });
+
+  $('#confirmDeleteBtn').on('click', function(){
     $.ajax({
-      url, type:'DELETE',
-      data:{ _token:'{{ csrf_token() }}' },
-      success(res){ toastr.success(res.message); loadTable(window.location.href.split('#')[0]); },
-      error(){ toastr.error('Unable to delete record'); }
+      url: deleteUrl,
+      type: 'DELETE',
+      data: { _token: '{{ csrf_token() }}' },
+      success(res){
+        $('#deleteConfirmModal').modal('hide');
+        toastr.success(res.message);
+        $('#row-'+deleteId).remove();
+      },
+      error(){
+        $('#deleteConfirmModal').modal('hide');
+        toastr.error('Unable to delete record');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- add YouTube-style delete confirmation modal with AJAX handling to category list
- integrate same modal-based delete flow for sub-category list

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*


------
https://chatgpt.com/codex/tasks/task_e_689cc6f4413483278e6a10977e191b27