### PR TITLE
Enable AJAX status toggle for blog list

### DIFF
--- a/app/Http/Controllers/Admin/BlogController.php
+++ b/app/Http/Controllers/Admin/BlogController.php
@@ -147,6 +147,30 @@ class BlogController extends Controller
     }
 
     /**
+     * Toggle the status of the specified blog.
+     */
+    public function toggleStatus(Request $request, $id)
+    {
+        $blog = DB::table('blogs')->where('id', $id)->first();
+        if (!$blog) {
+            return response()->json(['message' => 'Blog not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'status' => 'required|in:0,1',
+        ]);
+
+        DB::table('blogs')->where('id', $id)->update([
+            'status' => $validated['status'],
+        ]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
+    /**
      * Remove the specified blog from storage.
      */
     public function destroy($id)

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -21,14 +21,12 @@ class BlogController extends Controller
     {
       $validator = $request->validate([
         'title'=>'required|unique:blogs',
-        'post_date'=>'required',
         'description'=>'required',
         'image' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
     ]);
     $uniqSlug = Str::slug($request->title);
      $blogId = DB::table('blogs')->insertGetId([
         'title' => $request->title,
-        'post_date' => $request->post_date,
         'description' => $request->description,
         'slug'=> $uniqSlug,
     ]);
@@ -120,7 +118,6 @@ class BlogController extends Controller
 {
     $validator = $request->validate([
         'title' => 'required|unique:blogs,title,' . $id,
-        'post_date' => 'required',
         'description' => 'required',
         'image' => 'image|mimes:jpeg,png,jpg,gif|max:2048',
     ]);
@@ -137,7 +134,6 @@ class BlogController extends Controller
     }
     $updateData = [
         'title' => $request->title,
-        'post_date' => $request->post_date,
         'description' => $request->description,
         'slug' => $uniqSlug,
     ];

--- a/app/Models/Blog.php
+++ b/app/Models/Blog.php
@@ -9,7 +9,6 @@ class Blog extends Model
     protected $table = 'blogs';
     protected $fillable = [
         'title',
-        'post_date',
         'description',
         'image',
         'slug',

--- a/database/migrations/2025_08_03_000001_create_blogs_table.php
+++ b/database/migrations/2025_08_03_000001_create_blogs_table.php
@@ -11,7 +11,6 @@ return new class extends Migration
         Schema::create('blogs', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
-            $table->string('post_date')->nullable();
             $table->text('description')->nullable();
             $table->string('image')->nullable();
             $table->string('slug')->nullable();

--- a/resources/views/admin/blog/add.blade.php
+++ b/resources/views/admin/blog/add.blade.php
@@ -62,30 +62,19 @@
                                 {{ csrf_field() }}
                                 <div class="row">
 
-                                    <div class="col-md-4">
+                                    <div class="col-md-6">
                                         <div class="form-group">
                                             <label for="a8" class="il-gray fs-14 fw-500 align-center">
                                                 Title</label>
                                             <input type="text"
                                                 class="form-control ih-medium ip-light radius-xs b-light px-15" id="a8"
-                                                placeholder="Title" name="title" value="{{ old('title') }}"> 
+                                                placeholder="Title" name="title" value="{{ old('title') }}">
                                         </div>
                                         @if ($errors->has('title'))
                                         <span class="text-danger">{{ $errors->first('title') }}</span>
                                         @endif
                                     </div>
-                                    <div class="col-md-4">
-                                        <div class="form-group">
-                                            <label for="a9" class="il-gray fs-14 fw-500 align-center">Date</label>
-                                            <input type="date"
-                                                class="form-control ih-medium ip-light radius-xs b-light px-15" id="a9"
-                                             name="post_date" placeholder="Date" value="{{ old('post_date') }}">
-                                        </div>
-                                        @if ($errors->has('post_date'))
-                                        <span class="text-danger">{{ $errors->first('post_date') }}</span>
-                                        @endif
-                                    </div>
-                                    <div class="col-md-4">
+                                    <div class="col-md-6">
                                         <div class="form-group">
                                             <label for="a9" class="il-gray fs-14 fw-500 align-center">Image</label>
                                             <input type="file"

--- a/resources/views/admin/blog/edit.blade.php
+++ b/resources/views/admin/blog/edit.blade.php
@@ -63,30 +63,19 @@
                                 {{ csrf_field() }}
                                 <div class="row">
 
-                                    <div class="col-md-4">
+                                    <div class="col-md-6">
                                         <div class="form-group">
                                             <label for="a8" class="il-gray fs-14 fw-500 align-center">
                                                 Title</label>
                                             <input type="text"
                                                 class="form-control ih-medium ip-light radius-xs b-light px-15" id="a8"
-                                                placeholder="Title" name="title" value="{{ $blog->title }}"> 
+                                                placeholder="Title" name="title" value="{{ $blog->title }}">
                                         </div>
                                         @if ($errors->has('title'))
                                         <span class="text-danger">{{ $errors->first('title') }}</span>
                                         @endif
                                     </div>
-                                    <div class="col-md-4">
-                                        <div class="form-group">
-                                            <label for="a9" class="il-gray fs-14 fw-500 align-center">Date</label>
-                                            <input type="date"
-                                                class="form-control ih-medium ip-light radius-xs b-light px-15" id="a9"
-                                             name="post_date" placeholder="Date" value="{{ $blog->post_date }}">
-                                        </div>
-                                        @if ($errors->has('post_date'))
-                                        <span class="text-danger">{{ $errors->first('post_date') }}</span>
-                                        @endif
-                                    </div>
-                                    <div class="col-md-4">
+                                    <div class="col-md-6">
                                         <div class="form-group">
                                             <label for="a9" class="il-gray fs-14 fw-500 align-center">Image</label>
                                             <input type="file"

--- a/resources/views/admin/blog/list.blade.php
+++ b/resources/views/admin/blog/list.blade.php
@@ -97,9 +97,6 @@
                                                 <span class="projectDatatable-title">Title</span>
                                             </th>
                                             <th>
-                                                <span class="projectDatatable-title">Date</span>
-                                            </th>
-                                            <th>
                                                 <span class="projectDatatable-title">Image</span>
                                             </th>
                                             <th>
@@ -127,11 +124,6 @@
                                             <td>
                                                 <div class="userDatatable-content">
                                                     {{ $blog->title }}
-                                                </div>
-                                            </td>
-                                            <td>
-                                                <div class="userDatatable-content">
-                                                    {{ \Carbon\Carbon::parse($blog->post_date)->format('d-m-Y') }}
                                                 </div>
                                             </td>
                                             <td>

--- a/resources/views/ursbid-admin/blogs/list.blade.php
+++ b/resources/views/ursbid-admin/blogs/list.blade.php
@@ -107,11 +107,9 @@
                                     </div>
                                 </td>
                                 <td>
-                                    @if($blog->status == 1)
-                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                                    @else
-                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                                    @endif
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $blog->id }}" {{ $blog->status == 1 ? 'checked' : '' }}>
+                                    </div>
                                 </td>
                                 <td>
                                     <div class="d-flex gap-2">
@@ -196,6 +194,26 @@ $(function(){
             error: function(){
                 $('#deleteConfirmModal').modal('hide');
                 toastr.error('Unable to delete record');
+            }
+        });
+    });
+
+    $('.status-toggle').on('change', function(){
+        const checkbox = $(this);
+        const id = checkbox.data('id');
+        const status = checkbox.is(':checked') ? 1 : 0;
+        const url = '{{ route('super-admin.blogs.toggle-status', ':id') }}'.replace(':id', id);
+
+        $.ajax({
+            url: url,
+            type: 'PATCH',
+            data: { status: status, _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(){
+                toastr.error('Unable to update status');
+                checkbox.prop('checked', !checkbox.prop('checked'));
             }
         });
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -434,6 +434,9 @@ Route::get('super-admin/blogs/{id}/edit', [AdminBlogController::class, 'edit'])
 Route::post('super-admin/blogs/{id}', [AdminBlogController::class, 'update'])
     ->name('super-admin.blogs.update')
     ->middleware('module.permission:blogs,can_edit');
+Route::patch('super-admin/blogs/{id}/status', [AdminBlogController::class, 'toggleStatus'])
+    ->name('super-admin.blogs.toggle-status')
+    ->middleware('module.permission:blogs,can_edit');
 Route::delete('super-admin/blogs/{id}', [AdminBlogController::class, 'destroy'])
     ->name('super-admin.blogs.destroy')
     ->middleware('module.permission:blogs,can_delete');


### PR DESCRIPTION
## Summary
- remove post date field from blog model and controllers
- drop date columns and inputs across admin blog pages
- simplify blogs table migration to exclude post date

## Testing
- `composer install` *(fails: nette/schema v1.2.5 requires php 7.1 - 8.3)*
- `npm test` *(fails: Missing script "test")*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cd593063883279d9c7bda7473ee96