### PR TITLE
Add AJAX status toggles for categories and sub categories

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -116,6 +116,29 @@ class CategoryController extends Controller
         ]);
     }
 
+    public function toggleStatus(Request $request, $id)
+    {
+        $category = Category::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $category->update(['status' => $request->status]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
 
     public function destroy($id)
     {

--- a/app/Http/Controllers/Admin/SubCategoryController.php
+++ b/app/Http/Controllers/Admin/SubCategoryController.php
@@ -230,6 +230,30 @@ class SubCategoryController extends Controller
     }
 
     /**
+     * Toggle the status of the specified sub category.
+     */
+    public function toggleStatus(Request $request, $id)
+    {
+        $sub = DB::table('sub_categories')->where('id', $id)->first();
+        if (!$sub) {
+            return response()->json(['message' => 'Sub category not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'status' => 'required|in:1,2',
+        ]);
+
+        DB::table('sub_categories')->where('id', $id)->update([
+            'status' => $validated['status'],
+        ]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
+    /**
      * Remove the specified sub category from storage.
      */
     public function destroy($id)

--- a/resources/views/ursbid-admin/category/list.blade.php
+++ b/resources/views/ursbid-admin/category/list.blade.php
@@ -57,11 +57,9 @@
                                 </td>
                                 <td>{{ $category->created_at ? \Carbon\Carbon::parse($category->created_at)->format('d-m-Y') : '' }}</td>
                                 <td>
-                                    @if($category->status == '1')
-                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                                    @else
-                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                                    @endif
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $category->id }}" {{ $category->status == '1' ? 'checked' : '' }}>
+                                    </div>
                                 </td>
                                 <td>
                                     <div class="d-flex gap-2">
@@ -149,6 +147,26 @@ $(function(){
             error: function(){
                 $('#deleteConfirmModal').modal('hide');
                 toastr.error('Unable to delete record');
+            }
+        });
+    });
+
+    $(document).on('change', '.status-toggle', function(){
+        const checkbox = $(this);
+        const id = checkbox.data('id');
+        const status = checkbox.is(':checked') ? 1 : 2;
+        const url = '{{ route('super-admin.categories.toggle-status', ':id') }}'.replace(':id', id);
+
+        $.ajax({
+            url: url,
+            type: 'PATCH',
+            data: { status: status, _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(){
+                toastr.error('Unable to update status');
+                checkbox.prop('checked', !checkbox.prop('checked'));
             }
         });
     });

--- a/resources/views/ursbid-admin/sub_categories/list.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/list.blade.php
@@ -255,6 +255,26 @@
     });
   });
 
+  $(document).on('change', '.status-toggle', function(){
+    const checkbox = $(this);
+    const id = checkbox.data('id');
+    const status = checkbox.is(':checked') ? 1 : 2;
+    const url = '{{ route('super-admin.sub-categories.toggle-status', ':id') }}'.replace(':id', id);
+
+    $.ajax({
+      url: url,
+      type: 'PATCH',
+      data: { status: status, _token: '{{ csrf_token() }}' },
+      success(res){
+        toastr.success(res.message);
+      },
+      error(){
+        toastr.error('Unable to update status');
+        checkbox.prop('checked', !checkbox.prop('checked'));
+      }
+    });
+  });
+
   // Filter submit (AJAX)
   $(document).on('submit', '#filterForm', function(e){
     e.preventDefault();

--- a/resources/views/ursbid-admin/sub_categories/partials/table.blade.php
+++ b/resources/views/ursbid-admin/sub_categories/partials/table.blade.php
@@ -27,11 +27,9 @@
                 <td>{{ $sub->category_name }}</td>
                 <td>{{ $sub->created_at ? \Carbon\Carbon::parse($sub->created_at)->format('d-m-Y') : '' }}</td>
                 <td>
-                    @if($sub->status == '1')
-                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                    @else
-                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                    @endif
+                    <div class="form-check form-switch">
+                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $sub->id }}" {{ $sub->status == '1' ? 'checked' : '' }}>
+                    </div>
                 </td>
                 <td>
                     <div class="d-flex gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -395,6 +395,9 @@ Route::prefix('super-admin')->group(function () {
     Route::put('categories/{id}', [AdminCategoryController::class, 'update'])
         ->name('super-admin.categories.update')
         ->middleware('module.permission:categories,can_edit');
+    Route::patch('categories/{id}/status', [AdminCategoryController::class, 'toggleStatus'])
+        ->name('super-admin.categories.toggle-status')
+        ->middleware('module.permission:categories,can_edit');
     Route::delete('categories/{id}', [AdminCategoryController::class, 'destroy'])
         ->name('super-admin.categories.destroy')
         ->middleware('module.permission:categories,can_delete');
@@ -414,6 +417,9 @@ Route::get('super-admin/sub-categories/{id}/edit', [SubCategoryController::class
     ->middleware('module.permission:sub-categories,can_edit');
 Route::post('super-admin/sub-categories/{id}', [SubCategoryController::class, 'update'])
     ->name('super-admin.sub-categories.update')
+    ->middleware('module.permission:sub-categories,can_edit');
+Route::patch('super-admin/sub-categories/{id}/status', [SubCategoryController::class, 'toggleStatus'])
+    ->name('super-admin.sub-categories.toggle-status')
     ->middleware('module.permission:sub-categories,can_edit');
 Route::delete('super-admin/sub-categories/{id}', [SubCategoryController::class, 'destroy'])
     ->name('super-admin.sub-categories.destroy')


### PR DESCRIPTION
## Summary
- allow admins to toggle category status via AJAX switch
- enable AJAX status toggles for sub-category listing
- wire up routes and controllers for status updates

## Testing
- `php -l app/Http/Controllers/Admin/CategoryController.php`
- `php -l app/Http/Controllers/Admin/SubCategoryController.php`
- `php -l routes/web.php`
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc5d5ba88327891f199a1a31bdfb