### PR TITLE
Add AJAX status toggles for product, brand, and unit lists

### DIFF
--- a/app/Http/Controllers/Admin/ProductBrandController.php
+++ b/app/Http/Controllers/Admin/ProductBrandController.php
@@ -104,6 +104,29 @@ class ProductBrandController extends Controller
         ]);
     }
 
+    public function toggleStatus(Request $request, $id)
+    {
+        $brand = ProductBrand::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $brand->update(['status' => $request->status]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
     public function destroy($id)
     {
         $brand = ProductBrand::findOrFail($id);

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -224,6 +224,35 @@ class ProductController extends Controller
         ]);
     }
 
+    public function toggleStatus(Request $request, $id)
+    {
+        $product = DB::table('product')->where('id', $id)->first();
+        if (!$product) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Product not found.'
+            ], 404);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'status' => 'required|in:0,1',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        DB::table('product')->where('id', $id)->update(['status' => $request->status]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
     public function destroy($id)
     {
         $product = DB::table('product')->where('id', $id)->first();

--- a/app/Http/Controllers/Admin/UnitController.php
+++ b/app/Http/Controllers/Admin/UnitController.php
@@ -96,6 +96,29 @@ class UnitController extends Controller
         ]);
     }
 
+    public function toggleStatus(Request $request, $id)
+    {
+        $unit = Unit::findOrFail($id);
+
+        $validator = Validator::make($request->all(), [
+            'status' => 'required|in:1,2',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'status' => 'error',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $unit->update(['status' => $request->status]);
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Status updated successfully.',
+        ]);
+    }
+
     public function destroy($id)
     {
         $unit = Unit::findOrFail($id);

--- a/resources/views/ursbid-admin/product_brands/list.blade.php
+++ b/resources/views/ursbid-admin/product_brands/list.blade.php
@@ -96,11 +96,9 @@
                                 <td>{{ $brand->brand_name }}</td>
                                 <td>{{ \Carbon\Carbon::parse($brand->created_at)->format('d-m-Y') }}</td>
                                 <td>
-                                    @if($brand->status == '1')
-                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                                    @else
-                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                                    @endif
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $brand->id }}" {{ $brand->status == '1' ? 'checked' : '' }}>
+                                    </div>
                                 </td>
                                 <td>
                                     <div class="d-flex gap-2">
@@ -145,6 +143,25 @@ $(function(){
             },
             error: function(){
                 toastr.error('Unable to delete record');
+            }
+        });
+    });
+
+    $(document).on('change', '.status-toggle', function(){
+        const checkbox = $(this);
+        const id = checkbox.data('id');
+        const status = checkbox.is(':checked') ? 1 : 2;
+        const url = '{{ route('super-admin.product-brands.toggle-status', ':id') }}'.replace(':id', id);
+        $.ajax({
+            url: url,
+            type: 'PATCH',
+            data: { status: status, _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(){
+                toastr.error('Unable to update status');
+                checkbox.prop('checked', !checkbox.prop('checked'));
             }
         });
     });

--- a/resources/views/ursbid-admin/products/list.blade.php
+++ b/resources/views/ursbid-admin/products/list.blade.php
@@ -272,6 +272,25 @@
     });
   });
 
+  $(document).on('change', '.status-toggle', function(){
+    const checkbox = $(this);
+    const id = checkbox.data('id');
+    const status = checkbox.is(':checked') ? 1 : 0;
+    const url = '{{ route('super-admin.products.toggle-status', ':id') }}'.replace(':id', id);
+    $.ajax({
+      url: url,
+      type: 'PATCH',
+      data: { status: status, _token: '{{ csrf_token() }}' },
+      success(res){
+        toastr.success(res.message);
+      },
+      error(){
+        toastr.error('Unable to update status');
+        checkbox.prop('checked', !checkbox.prop('checked'));
+      }
+    });
+  });
+
   function loadTable(url){
     $.ajax({
       url, type:'GET',

--- a/resources/views/ursbid-admin/products/partials/table.blade.php
+++ b/resources/views/ursbid-admin/products/partials/table.blade.php
@@ -35,11 +35,9 @@
                 <td>{{ $product->category_name }}</td>
                 <td>{{ $product->sub_name }}</td>
                 <td>
-                    @if($product->status == 1)
-                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                    @else
-                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                    @endif
+                    <div class="form-check form-switch">
+                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $product->id }}" {{ $product->status == 1 ? 'checked' : '' }}>
+                    </div>
                 </td>
                 <td>
                     <div class="d-flex gap-2">

--- a/resources/views/ursbid-admin/unit/list.blade.php
+++ b/resources/views/ursbid-admin/unit/list.blade.php
@@ -94,11 +94,9 @@
                                 <td>{{ $unit->title }}</td>
                                 <td>{{ \Carbon\Carbon::parse($unit->created_at)->format('d-m-Y') }}</td>
                                 <td>
-                                    @if($unit->status == '1')
-                                        <span class="badge bg-success-subtle text-success py-1 px-2 fs-13">Active</span>
-                                    @else
-                                        <span class="badge bg-danger-subtle text-danger py-1 px-2 fs-13">Inactive</span>
-                                    @endif
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input status-toggle" type="checkbox" data-id="{{ $unit->id }}" {{ $unit->status == '1' ? 'checked' : '' }}>
+                                    </div>
                                 </td>
                                 <td>
                                     <div class="d-flex gap-2">
@@ -144,6 +142,25 @@ $(function(){
             },
             error: function(){
                 toastr.error('Unable to delete record');
+            }
+        });
+    });
+
+    $(document).on('change', '.status-toggle', function(){
+        const checkbox = $(this);
+        const id = checkbox.data('id');
+        const status = checkbox.is(':checked') ? 1 : 2;
+        const url = '{{ route('super-admin.units.toggle-status', ':id') }}'.replace(':id', id);
+        $.ajax({
+            url: url,
+            type: 'PATCH',
+            data: { status: status, _token: '{{ csrf_token() }}' },
+            success: function(res){
+                toastr.success(res.message);
+            },
+            error: function(){
+                toastr.error('Unable to update status');
+                checkbox.prop('checked', !checkbox.prop('checked'));
             }
         });
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -462,6 +462,9 @@ Route::get('super-admin/products/{id}/edit', [AdminProductController::class, 'ed
 Route::post('super-admin/products/{id}', [AdminProductController::class, 'update'])
     ->name('super-admin.products.update')
     ->middleware('module.permission:products,can_edit');
+Route::patch('super-admin/products/{id}/status', [AdminProductController::class, 'toggleStatus'])
+    ->name('super-admin.products.toggle-status')
+    ->middleware('module.permission:products,can_edit');
 Route::delete('super-admin/products/{id}', [AdminProductController::class, 'destroy'])
     ->name('super-admin.products.destroy')
     ->middleware('module.permission:products,can_delete');
@@ -483,6 +486,9 @@ Route::get('super-admin/units/{id}/edit', [UnitController::class, 'edit'])
     ->middleware('module.permission:units,can_edit');
 Route::put('super-admin/units/{id}', [UnitController::class, 'update'])
     ->name('super-admin.units.update')
+    ->middleware('module.permission:units,can_edit');
+Route::patch('super-admin/units/{id}/status', [UnitController::class, 'toggleStatus'])
+    ->name('super-admin.units.toggle-status')
     ->middleware('module.permission:units,can_edit');
 Route::delete('super-admin/units/{id}', [UnitController::class, 'destroy'])
     ->name('super-admin.units.destroy')
@@ -559,6 +565,9 @@ Route::get('super-admin/product-brands/{id}/edit', [ProductBrandController::clas
     ->middleware('module.permission:product-brands,can_edit');
 Route::put('super-admin/product-brands/{id}', [ProductBrandController::class, 'update'])
     ->name('super-admin.product-brands.update')
+    ->middleware('module.permission:product-brands,can_edit');
+Route::patch('super-admin/product-brands/{id}/status', [ProductBrandController::class, 'toggleStatus'])
+    ->name('super-admin.product-brands.toggle-status')
     ->middleware('module.permission:product-brands,can_edit');
 Route::delete('super-admin/product-brands/{id}', [ProductBrandController::class, 'destroy'])
     ->name('super-admin.product-brands.destroy')


### PR DESCRIPTION
## Summary
- add form-switch status toggles to product, product brand and unit listings
- introduce toggleStatus endpoints with validation in controllers and routes
- wire up AJAX handlers for client-side status updates

## Testing
- ⚠️ `phpunit` *(command not found)*
- ⚠️ `composer install` *(nette/schema requires php 7.1-8.3)*

------
https://chatgpt.com/codex/tasks/task_e_689ce12aa0a48327a064372aa09acf63