### PR TITLE
Fix seller modals for Bootstrap 5

### DIFF
--- a/resources/views/seller/accounting/view.blade.php
+++ b/resources/views/seller/accounting/view.blade.php
@@ -46,9 +46,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <form action="{{ url('/bidding_price') }}" method="POST">

--- a/resources/views/seller/accounting/viewwork.blade.php
+++ b/resources/views/seller/accounting/viewwork.blade.php
@@ -46,9 +46,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <form action="{{ url('/openqotationpage') }}" method="POST">

--- a/resources/views/seller/buyer-order/acc-list.blade.php
+++ b/resources/views/seller/buyer-order/acc-list.blade.php
@@ -46,9 +46,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <form action="{{ url('/bidding_price') }}" method="POST">

--- a/resources/views/seller/buyer-order/list.blade.php
+++ b/resources/views/seller/buyer-order/list.blade.php
@@ -46,9 +46,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <form action="{{ url('/bidding_price') }}" method="POST">

--- a/resources/views/seller/buyer-order/mylist.blade.php
+++ b/resources/views/seller/buyer-order/mylist.blade.php
@@ -46,9 +46,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <form action="{{ url('/bidding_price') }}" method="POST">

--- a/resources/views/seller/category/list.blade.php
+++ b/resources/views/seller/category/list.blade.php
@@ -149,7 +149,7 @@
                                                     <div class="dropdown  dropdown-click ">
 
                                                         <button class="btn-link border-0 bg-transparent p-0"
-                                                            data-toggle="dropdown" aria-haspopup="true"
+                                                            data-bs-toggle="dropdown" aria-haspopup="true"
                                                             aria-expanded="false">
                                                             <span data-feather=more-horizontal></span>
                                                         </button>

--- a/resources/views/seller/enquiry/deactivelist.blade.php
+++ b/resources/views/seller/enquiry/deactivelist.blade.php
@@ -17,9 +17,7 @@
             <div class="modal-content">
                <div class="modal-header">
                   <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
-                  </button>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                </div>
                <div class="modal-body">
                   <form action="{{ url('/bidding_price') }}" method="POST">
@@ -253,8 +251,8 @@
                                     </a>
                                     @if($status == 'active')
                                     <a href="#!" class="btn btn-primary btn-sm me-2"
-                                       data-toggle="modal"
-                                       data-target="#exampleModalCenter"
+                                       data-bs-toggle="modal"
+                                       data-bs-target="#exampleModalCenter"
                                        product_id='{{ $blog->product_id }}'
                                        product_name='{{ $blog->product_name }}'
                                        data_id='{{ $blog->id }}'

--- a/resources/views/seller/enquiry/list.blade.php
+++ b/resources/views/seller/enquiry/list.blade.php
@@ -23,9 +23,7 @@
             <div class="modal-content">
                <div class="modal-header">
                   <h5 class="modal-title">Bidding Price</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                     <span aria-hidden="true">&times;</span>
-                  </button>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                </div>
                <div class="modal-body">
                   <form action="{{ url('/openqotationpage') }}" method="POST" enctype="multipart/form-data">
@@ -64,8 +62,8 @@
                      <div class="d-flex mt-3">
                         <input type="checkbox" id="myCheckbox" required>
                         <span class="ms-2">I accept all the</span>&nbsp; 
-                        <a href="#!" class="exampleModalCentersmall" data-toggle="modal"
-                           data-target="#exampleModalCentersmall">agreement terms & condition</a>
+                        <a href="#!" class="exampleModalCentersmall" data-bs-toggle="modal"
+                           data-bs-target="#exampleModalCentersmall">agreement terms & condition</a>
                      </div>
 
                      <button type="submit" class="btn btn-primary mt-3">Submit</button>
@@ -82,9 +80,7 @@
             <div class="modal-content">
                <div class="modal-header">
                   <h5 class="modal-title">Terms & Condition</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                     <span aria-hidden="true">&times;</span>
-                  </button>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                </div>
                <div class="modal-body">
                   <p>This Service Agreement ("Agreement") is valid from the date of quotation acceptance 
@@ -95,7 +91,7 @@
                      <a href="{{ url('/accept-terms-condition') }}"><small>Read More</small></a>
                   </div>
                   <div class="input-item mb-2 d-flex gap-2">
-                     <input type="checkbox" class="close" data-dismiss="modal" value="term_and_cond_acc" required>
+                     <input type="checkbox" data-bs-dismiss="modal" value="term_and_cond_acc" required>
                      I have read and accept the terms and conditions
                   </div>
                </div>
@@ -289,7 +285,7 @@
 
                                        @if($showBiddingButton)
                                           <a href="#!" class="btn btn-outline-primary mdl_btn"
-                                             data-toggle="modal" data-target="#exampleModalCenter"
+                                             data-bs-toggle="modal" data-bs-target="#exampleModalCenter"
                                              product_id="{{ $blog->product_id }}"
                                              product_quantity="{{ $blog->quantity }}"
                                              product_name="{{ $blog->product_name }}"

--- a/resources/views/seller/enquiry/myenclist.blade.php
+++ b/resources/views/seller/enquiry/myenclist.blade.php
@@ -17,9 +17,7 @@
             <div class="modal-content">
                <div class="modal-header">
                   <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
-                  </button>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                </div>
                <div class="modal-body">
                   <form action="{{ url('/openqotationpage') }}" method="POST" enctype="multipart/form-data">
@@ -56,7 +54,7 @@
                      </div>
                      <div class="d-flex  ">
                         <input type="checkbox" id="myCheckbox" required> &nbsp; I accept all the  &nbsp; 
-                        <a data-toggle="modal" href="#!" class="exampleModalCentersmall" data-target="#exampleModalCentersmall"> agreement terms & condition </a>
+                        <a data-bs-toggle="modal" href="#!" class="exampleModalCentersmall" data-bs-target="#exampleModalCentersmall"> agreement terms & condition </a>
                      </div>
                      <button type="submit" class="btn btn-primary mt-2">Submit</button>
                   </form>
@@ -80,7 +78,7 @@
                      <a href="{{url('/accept-terms-condition')}}"><small>Read More</small></a>
                   </div>
                   <div class="input-item input-item-textarea ltn__custom-icon mb-4 d-flex gap-3" >
-                     <input type="checkbox" class="close" data-dismiss="modal" aria-label="Close" name="term_and_condition" required="" value="term_and_cond_acc"> I have read and accept the terms and
+                     <input type="checkbox" data-bs-dismiss="modal" aria-label="Close" name="term_and_condition" required="" value="term_and_cond_acc"> I have read and accept the terms and
                      conditions
                   </div>
                </div>

--- a/resources/views/seller/enquiry/view.blade.php
+++ b/resources/views/seller/enquiry/view.blade.php
@@ -17,9 +17,7 @@
             <div class="modal-content">
                <div class="modal-header">
                   <h5 class="modal-title" id="exampleModalLongTitle">Bidding Price</h5>
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
-                  </button>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                </div>
                <div class="modal-body">
                   <form action="{{ url('/bidding_price') }}" method="POST">

--- a/resources/views/seller/product/list.blade.php
+++ b/resources/views/seller/product/list.blade.php
@@ -178,7 +178,7 @@
                                                     <div class="dropdown  dropdown-click ">
 
                                                         <button class="btn-link border-0 bg-transparent p-0"
-                                                            data-toggle="dropdown" aria-haspopup="true"
+                                                            data-bs-toggle="dropdown" aria-haspopup="true"
                                                             aria-expanded="false">
                                                             <span data-feather=more-horizontal></span>
                                                         </button>

--- a/resources/views/seller/wizz/list.blade.php
+++ b/resources/views/seller/wizz/list.blade.php
@@ -149,7 +149,7 @@
                                                     <div class="dropdown  dropdown-click ">
 
                                                         <button class="btn-link border-0 bg-transparent p-0"
-                                                            data-toggle="dropdown" aria-haspopup="true"
+                                                            data-bs-toggle="dropdown" aria-haspopup="true"
                                                             aria-expanded="false">
                                                             <span data-feather=more-horizontal></span>
                                                         </button>

--- a/resources/views/seller/wizz/three.blade.php
+++ b/resources/views/seller/wizz/three.blade.php
@@ -162,7 +162,7 @@
                                                     <!-- <div class="dropdown  dropdown-click ">
 
                                                         <button class="btn-link border-0 bg-transparent p-0"
-                                                            data-toggle="dropdown" aria-haspopup="true"
+                                                            data-bs-toggle="dropdown" aria-haspopup="true"
                                                             aria-expanded="false">
                                                             <span data-feather=more-horizontal></span>
                                                         </button>


### PR DESCRIPTION
## Summary
- update seller modal triggers to use Bootstrap 5 `data-bs-*` attributes
- replace deprecated modal close markup with the Bootstrap 5 `btn-close` button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8517c80f08327ac26eb289d393b36