### PR TITLE
Align active enquiry listing with inline AJAX filtering

### DIFF
--- a/app/Http/Controllers/URSController/ActiveEnquiryController.php
+++ b/app/Http/Controllers/URSController/ActiveEnquiryController.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace App\Http\Controllers\URSController;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ActiveEnquiryController extends Controller
+{
+    public function index(Request $request, $id = null)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (!$seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        $perPage = (int) $request->input('r_page', 25);
+
+        $filters = [
+            'category' => $request->has('category') ? $request->input('category') : $id,
+            'date' => $request->input('date'),
+            'city' => $request->input('city'),
+            'quantity' => $request->input('quantity'),
+            'product_name' => $request->input('product_name'),
+            'r_page' => $perPage,
+        ];
+
+        $query = $this->baseActiveEnquiryQuery($seller->id, $seller->email);
+
+        if ($request->filled('category')) {
+            $query->where('c.id', $request->input('category'));
+        } elseif (!$request->has('category') && $id) {
+            $query->where('c.id', $id);
+        }
+
+        if ($request->filled('date')) {
+            $query->where('qutation_form.date_time', 'like', '%' . $request->input('date') . '%');
+        }
+
+        if ($request->filled('city')) {
+            $query->where('qutation_form.city', 'like', '%' . $request->input('city') . '%');
+        }
+
+        if ($request->filled('quantity')) {
+            $query->where('qutation_form.quantity', 'like', '%' . $request->input('quantity') . '%');
+        }
+
+        if ($request->filled('product_name')) {
+            $query->where('product.title', 'like', '%' . $request->input('product_name') . '%');
+        }
+
+        $blogs = $query
+            ->orderBy('qutation_form.id', 'desc')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        $blogs = $this->appendComputedState($blogs, $seller->email);
+
+        $categoryData = DB::table('categories')
+            ->select('id', 'name', 'title')
+            ->orderBy('name')
+            ->get();
+
+        if ($request->ajax()) {
+            return view('ursdashboard.active-enquiry.partials.table', [
+                'blogs' => $blogs,
+                'data' => $filters,
+                'sellerEmail' => $seller->email,
+            ])->render();
+        }
+
+        return view('ursdashboard.active-enquiry.list', [
+            'blogs' => $blogs,
+            'data' => $filters,
+            'category_data' => $categoryData,
+            'sellerEmail' => $seller->email,
+            'selectedCategoryId' => $id,
+        ]);
+    }
+
+    public function show(Request $request, $id)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (!$seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        $query = DB::table('qutation_form')
+            ->leftJoin('seller', 'qutation_form.email', '=', 'seller.email')
+            ->leftJoin('product', 'qutation_form.product_id', '=', 'product.id')
+            ->leftJoin('product_brands as pb', 'product.id', '=', 'pb.product_id')
+            ->leftJoin('sub_categories as sc', 'product.sub_id', '=', 'sc.id')
+            ->leftJoin('categories as c', 'sc.category_id', '=', 'c.id')
+            ->where('qutation_form.id', $id)
+            ->select(
+                'qutation_form.id as qutation_form_id',
+                'qutation_form.name as qutation_form_name',
+                'qutation_form.email as qutation_form_email',
+                'qutation_form.product_id as qutation_form_product_id',
+                'qutation_form.product_img as qutation_form_product_img',
+                'qutation_form.product_name as qutation_form_product_name',
+                'pb.brand_name as qutation_form_product_brand',
+                'qutation_form.message as qutation_form_message',
+                'qutation_form.location as qutation_form_location',
+                'qutation_form.address as qutation_form_address',
+                'qutation_form.zipcode as qutation_form_zipcode',
+                'qutation_form.state as qutation_form_state',
+                'qutation_form.city as qutation_form_city',
+                'qutation_form.bid_area as qutation_form_bid_area',
+                'qutation_form.bid_time as qutation_form_bid_time',
+                'qutation_form.material as qutation_form_material',
+                'qutation_form.image as qutation_form_image',
+                'qutation_form.latitude as qutation_form_latitude',
+                'qutation_form.longitude as qutation_form_longitude',
+                'qutation_form.seller_id as qutation_form_seller_id',
+                'qutation_form.unit as qutation_form_unit',
+                'qutation_form.quantity as qutation_form_quantity',
+                'qutation_form.status as qutation_form_status',
+                'seller.id as seller_id',
+                'seller.email as seller_email',
+                'seller.name as seller_name',
+                'seller.phone as seller_phone',
+                'seller.hash_id as seller_hash_id',
+                'seller.pro_ser as seller_pro_ser',
+                'product.id as product_id',
+                'product.title as product_name',
+                'product.sub_id as product_sub_id',
+                'product.user_id as product_user_id',
+                'product.cat_id as product_cat_id',
+                'product.super_id as product_super_id',
+                'product.description as product_description',
+                'product.image as product_image',
+                'product.user_type as product_user_type',
+                'product.insert_by as product_insert_by',
+                'product.update_by as product_update_by',
+                'product.slug as product_slug',
+                'product.status as product_status',
+                'product.order_by as product_order_by',
+                'sc.id as sub_id',
+                'sc.name as sub_name',
+                'sc.category_id as sub_cat_id',
+                'sc.created_at as sub_created_at',
+                'sc.image as sub_image',
+                'sc.slug as sub_slug',
+                'sc.status as sub_status',
+                'sc.order_by as sub_order_by',
+                'c.id as category_id',
+                'c.name as category_name',
+                'c.created_at as category_created_at',
+                'c.image as category_image',
+                'c.slug as category_slug',
+                'c.status as category_status'
+            )
+            ->first();
+
+        abort_if(!$query, 404);
+
+        return view('ursdashboard.active-enquiry.view', [
+            'query' => $query,
+            'sellerEmail' => $seller->email,
+        ]);
+    }
+
+    protected function baseActiveEnquiryQuery($sellerId, string $sellerEmail)
+    {
+        $currentDate = Carbon::now();
+
+        return DB::table('qutation_form')
+            ->leftJoin('seller', 'qutation_form.email', '=', 'seller.email')
+            ->leftJoin('product', 'qutation_form.product_id', '=', 'product.id')
+            ->leftJoin('product_brands as pb', 'product.id', '=', 'pb.product_id')
+            ->leftJoin('sub_categories as sc', 'product.sub_id', '=', 'sc.id')
+            ->leftJoin('categories as c', 'sc.category_id', '=', 'c.id')
+            ->where('qutation_form.email', '!=', $sellerEmail)
+            ->whereRaw('FIND_IN_SET(?, qutation_form.seller_id)', [$sellerId])
+            ->whereRaw('DATE_ADD(date_time, INTERVAL bid_time DAY) >= ?', [$currentDate])
+            ->select(
+                'qutation_form.id as id',
+                'qutation_form.name as name',
+                'qutation_form.email as email',
+                'qutation_form.product_id as qutation_form_product_id',
+                'qutation_form.product_img as qutation_form_product_img',
+                'qutation_form.product_name as qutation_form_product_name',
+                'pb.brand_name as qutation_form_product_brand',
+                'qutation_form.message as qutation_form_message',
+                'qutation_form.location as qutation_form_location',
+                'qutation_form.address as qutation_form_address',
+                'qutation_form.zipcode as qutation_form_zipcode',
+                'qutation_form.state as qutation_form_state',
+                'qutation_form.city as qutation_form_city',
+                'qutation_form.bid_area as qutation_form_bid_area',
+                'qutation_form.date_time as date_time',
+                'qutation_form.bid_time as bid_time',
+                'qutation_form.material as qutation_form_material',
+                'qutation_form.image as qutation_form_image',
+                'qutation_form.latitude as qutation_form_latitude',
+                'qutation_form.longitude as qutation_form_longitude',
+                'qutation_form.seller_id as qutation_form_seller_id',
+                'qutation_form.unit as unit',
+                'qutation_form.quantity as quantity',
+                'qutation_form.status as qutation_form_status',
+                'seller.id as seller_id',
+                'seller.email as seller_email',
+                'seller.name as seller_name',
+                'seller.phone as seller_phone',
+                'seller.hash_id as seller_hash_id',
+                'seller.pro_ser as seller_pro_ser',
+                'product.id as product_id',
+                'product.title as product_name',
+                'product.sub_id as product_sub_id',
+                'product.user_id as product_user_id',
+                'product.cat_id as product_cat_id',
+                'product.super_id as product_super_id',
+                'product.description as product_description',
+                'product.image as product_image',
+                'product.user_type as product_user_type',
+                'product.insert_by as product_insert_by',
+                'product.update_by as product_update_by',
+                'product.slug as product_slug',
+                'product.status as product_status',
+                'product.order_by as product_order_by',
+                'sc.id as sub_id',
+                'sc.name as sub_name',
+                'sc.category_id as sub_cat_id',
+                'sc.created_at as sub_created_at',
+                'sc.image as sub_image',
+                'sc.slug as sub_slug',
+                'sc.status as sub_status',
+                'sc.order_by as sub_order_by',
+                'c.id as category_id',
+                'c.name as category_name',
+                'c.created_at as category_created_at',
+                'c.image as category_image',
+                'c.slug as category_slug',
+                'c.status as category_status'
+            );
+    }
+
+    protected function appendComputedState(LengthAwarePaginator $blogs, string $sellerEmail): LengthAwarePaginator
+    {
+        $currentDate = Carbon::now();
+        $collection = $blogs->getCollection();
+        $ids = $collection->pluck('id')->filter()->values();
+
+        $lockedByAdmin = collect();
+        $lockedForSeller = collect();
+
+        if ($ids->isNotEmpty()) {
+            $lockedByAdmin = DB::table('bidding_price')
+                ->whereIn('data_id', $ids)
+                ->where('payment_status', 'success')
+                ->where('action', '1')
+                ->where('hide', '1')
+                ->pluck('data_id')
+                ->unique();
+
+            $lockedForSeller = DB::table('bidding_price')
+                ->whereIn('data_id', $ids)
+                ->where('payment_status', 'success')
+                ->where('seller_email', $sellerEmail)
+                ->pluck('data_id')
+                ->unique();
+        }
+
+        $collection->transform(function ($blog) use ($currentDate, $lockedByAdmin, $lockedForSeller) {
+            $status = 'active';
+
+            if (!empty($blog->date_time) && !empty($blog->bid_time)) {
+                $expirationDate = Carbon::parse($blog->date_time)->addDays((int) $blog->bid_time);
+                if ($currentDate->greaterThanOrEqualTo($expirationDate)) {
+                    $status = 'deactive';
+                }
+            }
+
+            $blog->status_badge = $status;
+            $blog->show_bidding_button = $status === 'active'
+                && !$lockedByAdmin->contains($blog->id)
+                && !$lockedForSeller->contains($blog->id);
+
+            return $blog;
+        });
+
+        return $blogs;
+    }
+}

--- a/resources/views/ursdashboard/active-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/list.blade.php
@@ -1,0 +1,291 @@
+@extends('seller.layouts.app')
+@section('title', 'Active Enquiry List')
+
+@section('content')
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+@php
+   $activeEnquiryBaseUrl = isset($selectedCategoryId) && $selectedCategoryId !== null
+       ? route('seller.enquiry.list', ['id' => $selectedCategoryId])
+       : route('seller.enquiry.list');
+@endphp
+<div class="container-fluid">
+   <div class="social-dash-wrap">
+      <div class="row">
+         <div class="col-lg-12">
+            <div class="breadcrumb-main">
+               <h4 class="text-capitalize breadcrumb-title">Active Enquiry List</h4>
+            </div>
+         </div>
+      </div>
+
+      <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+         <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+               <div class="modal-header">
+                  <h5 class="modal-title">Bidding Price</h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+               </div>
+               <div class="modal-body">
+                  <form action="{{ url('/openqotationpage') }}" method="POST" enctype="multipart/form-data">
+                     @csrf
+                     <input type="hidden" name="seller_email" value="{{ $sellerEmail }}">
+                     <input type="hidden" name="product_id" class="product_id form-control">
+                     <input type="hidden" name="product_quantity" class="product_quantity form-control">
+                     <input type="hidden" name="product_name" class="product_name form-control">
+                     <input type="hidden" name="user_email" class="user_email form-control">
+                     <input type="hidden" name="data_id" class="data_id form-control">
+
+                     <div class="d-flex gap-3">
+                        <div class="flex-grow-1">
+                           <label class="font-weight-bold">Enter Price</label>
+                           <input type="number" name="price" required class="price form-control" placeholder="Enter Price" min="1">
+                        </div>
+                        <div>
+                           <label class="font-weight-bold">Quantity</label>
+                           <input readonly class="product_quantity form-control">
+                        </div>
+                     </div>
+
+                     <div class="d-flex justify-content-between mt-3 gap-3 flex-wrap">
+                        <div class="d-flex align-items-center">
+                           <span class="font-weight-bold">Total :- </span>
+                           <span class="total ms-2">0.00</span>
+                        </div>
+                        <div class="flex-grow-1">
+                           <label class="font-weight-bold">Quotation file (optional)</label>
+                           <input type="file" name="file" class="form-control">
+                        </div>
+                     </div>
+
+                     <div class="d-flex mt-3 align-items-center">
+                        <input type="checkbox" id="myCheckbox" required>
+                        <span class="ms-2">I accept all the</span>&nbsp;
+                        <a href="#!" class="exampleModalCentersmall" data-bs-toggle="modal" data-bs-target="#exampleModalCentersmall">agreement terms & condition</a>
+                     </div>
+
+                     <button type="submit" class="btn btn-primary mt-3">Submit</button>
+                  </form>
+               </div>
+            </div>
+         </div>
+      </div>
+
+      <div class="modal fade" id="exampleModalCentersmall" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+         <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+               <div class="modal-header">
+                  <h5 class="modal-title">Terms & Condition</h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+               </div>
+               <div class="modal-body">
+                  <p>This Service Agreement ("Agreement") is valid from the date of quotation acceptance until the supply of material or completion of the work (as per the quotation).</p>
+                  <p class="mb-2">URSBID, a company registered under the Companies Act, 2013, having its registered address at Parewpur, Dharshawa, Shrawasti 271835</p>
+                  <div class="go-to-btn mb-3">
+                     <a href="{{ url('/accept-terms-condition') }}"><small>Read More</small></a>
+                  </div>
+                  <div class="input-item mb-2 d-flex gap-2">
+                     <input type="checkbox" data-bs-dismiss="modal" value="term_and_cond_acc" required>
+                     I have read and accept the terms and conditions
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+
+      <div class="row">
+         <div class="col-lg-12 mb-30">
+            <div class="card mb-4 shadow-sm">
+               <div class="card-header border-0 bg-white d-flex justify-content-between align-items-center flex-wrap gap-2">
+                  <h5 class="mb-0">Filter Enquiries</h5>
+                  <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#activeEnquiryFilters" aria-expanded="true" aria-controls="activeEnquiryFilters">
+                     Toggle Filters
+                  </button>
+               </div>
+
+               <div class="collapse show" id="activeEnquiryFilters">
+                  <div class="card-body">
+                     <form id="activeEnquiryFiltersForm" class="row g-3 align-items-end" method="get" action="{{ $activeEnquiryBaseUrl }}">
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Category</label>
+                           <select name="category" id="category" class="form-select">
+                              <option value="">Select Category</option>
+                              @foreach($category_data as $cat)
+                                 <option value="{{ $cat->id }}" {{ $data['category'] == $cat->id ? 'selected' : '' }}>
+                                    {{ $cat->name ?? $cat->title ?? '' }}
+                                 </option>
+                              @endforeach
+                           </select>
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Date</label>
+                           <input type="text" name="date" id="filterDate" class="form-control" placeholder="Date" value="{{ $data['date'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">City</label>
+                           <input type="text" name="city" id="filterCity" class="form-control" placeholder="City" value="{{ $data['city'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Quantity</label>
+                           <input type="text" name="quantity" id="filterQuantity" class="form-control" placeholder="Quantity" value="{{ $data['quantity'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Product Name</label>
+                           <input type="text" name="product_name" id="filterProduct" class="form-control" placeholder="Product Name" value="{{ $data['product_name'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Records Per Page</label>
+                           <select name="r_page" id="recordsPerPage" class="form-select">
+                              <option value="25" {{ $data['r_page'] == 25 ? 'selected' : '' }}>25</option>
+                              <option value="50" {{ $data['r_page'] == 50 ? 'selected' : '' }}>50</option>
+                              <option value="100" {{ $data['r_page'] == 100 ? 'selected' : '' }}>100</option>
+                           </select>
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label d-none d-lg-block">&nbsp;</label>
+                           <button type="submit" class="btn btn-primary w-100">
+                              <i class="bi bi-funnel-fill me-2"></i>Apply Filters
+                           </button>
+                        </div>
+                     </form>
+                  </div>
+               </div>
+            </div>
+
+            @if(Session::has('success'))
+               <div class="alert alert-success alert-dismissible fade show">
+                  {{ Session::get('success') }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            @if(Session::has('error'))
+               <div class="alert alert-danger alert-dismissible fade show">
+                  {{ Session::get('error') }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            @if ($errors->any())
+               <div class="alert alert-danger alert-dismissible fade show">
+                  <ul class="mb-0">
+                     @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                     @endforeach
+                  </ul>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            <div class="card shadow-sm">
+               <div class="card-body">
+                  <div id="activeEnquiryTable">
+                     @include('ursdashboard.active-enquiry.partials.table', ['blogs' => $blogs, 'data' => $data, 'sellerEmail' => $sellerEmail])
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>
+
+<script>
+   (function ($) {
+      const $form = $('#activeEnquiryFiltersForm');
+      const $tableWrapper = $('#activeEnquiryTable');
+      const baseUrl = "{{ $activeEnquiryBaseUrl }}";
+
+      function updateHistory(url, serializedForm) {
+         const params = new URLSearchParams(serializedForm);
+         const requestUrl = new URL(url, window.location.origin);
+         const page = requestUrl.searchParams.get('page');
+
+         if (page) {
+            params.set('page', page);
+         } else {
+            params.delete('page');
+         }
+
+         const finalUrl = params.toString() ? `${baseUrl}?${params.toString()}` : baseUrl;
+         window.history.replaceState({}, '', finalUrl);
+      }
+
+      function showLoader() {
+         $tableWrapper.addClass('position-relative');
+         if (!$tableWrapper.find('.table-loader').length) {
+            const loader = $('<div class="table-loader position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center bg-white bg-opacity-75"><div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div></div>');
+            $tableWrapper.append(loader);
+         }
+      }
+
+      function hideLoader() {
+         $tableWrapper.find('.table-loader').remove();
+      }
+
+      function fetchActiveEnquiries(url) {
+         const requestUrl = url || baseUrl;
+         const formData = $form.serialize();
+
+         $.ajax({
+            url: requestUrl,
+            data: formData,
+            type: 'GET',
+            beforeSend: showLoader,
+            success: function (response) {
+               $tableWrapper.html(response);
+               updateHistory(requestUrl, formData);
+            },
+            error: function () {
+               $tableWrapper.html('<div class="alert alert-danger mb-0">Unable to load enquiries. Please try again.</div>');
+            },
+            complete: hideLoader
+         });
+      }
+
+      $form.on('submit', function (event) {
+         event.preventDefault();
+         fetchActiveEnquiries();
+      });
+
+      $form.on('change', '#recordsPerPage', function () {
+         $form.trigger('submit');
+      });
+
+      $(document).on('click', '#activeEnquiryTable .pagination a', function (event) {
+         event.preventDefault();
+         const url = $(this).attr('href');
+         if (url) {
+            fetchActiveEnquiries(url);
+         }
+      });
+
+      $(document).on('click', '#activeEnquiryTable .mdl_btn', function () {
+         const $btn = $(this);
+         const $modal = $('#exampleModalCenter');
+
+         $modal.find('.product_quantity').val($btn.data('product-quantity'));
+         $modal.find('.product_id').val($btn.data('product-id'));
+         $modal.find('.product_name').val($btn.data('product-name'));
+         $modal.find('.user_email').val($btn.data('user-email'));
+         $modal.find('.data_id').val($btn.data('data-id'));
+         $modal.find('.price').val('');
+         $modal.find('.total').text('0.00');
+      });
+
+      $('#exampleModalCenter').on('input', '.price, .product_quantity', function () {
+         const price = parseFloat($('#exampleModalCenter .price').val()) || 0;
+         const quantity = parseFloat($('#exampleModalCenter .product_quantity').val()) || 0;
+         $('#exampleModalCenter .total').text((price * quantity).toFixed(2));
+      });
+
+      $(document).on('click', '.exampleModalCentersmall', function () {
+         $('#myCheckbox').prop('checked', true);
+      });
+   })(jQuery);
+</script>
+@endsection

--- a/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
@@ -1,0 +1,79 @@
+<div class="table-responsive">
+   <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+      <thead>
+         <tr>
+            <th>Sr no</th>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Sub Category</th>
+            <th>Product Name</th>
+            <th>Time</th>
+            <th>Date</th>
+            <th>Quantity</th>
+            <th>Unit</th>
+            <th>Quotation</th>
+            <th>Status</th>
+            <th>Action</th>
+         </tr>
+      </thead>
+      <tbody>
+         @forelse ($blogs as $index => $blog)
+            <tr>
+               <td>{{ ($blogs->currentPage() - 1) * $blogs->perPage() + $index + 1 }}</td>
+               <td>{{ $blog->name }}</td>
+               <td>{{ $blog->category_name }}</td>
+               <td>{{ $blog->sub_name }}</td>
+               <td>{{ $blog->product_name }}</td>
+               <td>{{ $blog->bid_time }} day</td>
+               <td>{{ $blog->date_time ? \Carbon\Carbon::parse($blog->date_time)->format('Y-m-d') : '-' }}</td>
+               <td>{{ $blog->quantity }}</td>
+               <td>{{ $blog->unit }}</td>
+               <td>
+                  @if(!empty($blog->qutation_form_image))
+                     <a href="{{ url('seller/enquiry/file/'.$blog->id) }}" target="_blank">View</a>
+                  @else
+                     No file found
+                  @endif
+               </td>
+               <td>
+                  <span class="badge {{ $blog->status_badge === 'active' ? 'bg-success-subtle text-success' : 'bg-danger-subtle text-danger' }} py-1 px-2 fs-13">
+                     {{ $blog->status_badge }}
+                  </span>
+               </td>
+               <td>
+                  <div class="d-flex gap-2 flex-wrap">
+                     <a href="{{ url('seller/enquiry/view/'.$blog->id) }}" class="btn btn-primary btn-sm">
+                        <i class="bi bi-eye me-1"></i>View
+                     </a>
+                     @if($blog->show_bidding_button)
+                        <a href="#!" class="btn btn-outline-primary btn-sm mdl_btn"
+                           data-bs-toggle="modal" data-bs-target="#exampleModalCenter"
+                           data-product-id="{{ $blog->product_id }}"
+                           data-product-quantity="{{ $blog->quantity }}"
+                           data-product-name="{{ $blog->product_name }}"
+                           data-data-id="{{ $blog->id }}"
+                           data-user-email="{{ $blog->email }}">
+                           <i class="bi bi-gavel me-1"></i>Bidding
+                        </a>
+                     @else
+                        <span class="btn btn-outline-danger btn-sm disabled">
+                           <i class="bi bi-lock-fill me-1"></i>Closed
+                        </span>
+                     @endif
+                  </div>
+               </td>
+            </tr>
+         @empty
+            <tr>
+               <td colspan="12" class="text-center py-4">No enquiries found.</td>
+            </tr>
+         @endforelse
+      </tbody>
+   </table>
+</div>
+
+@if ($blogs->hasPages())
+   <div class="mt-3">
+      {{ $blogs->links('pagination::bootstrap-4') }}
+   </div>
+@endif

--- a/resources/views/ursdashboard/active-enquiry/view.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/view.blade.php
@@ -1,0 +1,99 @@
+@extends('seller.layouts.app')
+@section('title', 'Enquiry Details')
+
+@section('content')
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<div class="container-fluid">
+   <div class="social-dash-wrap">
+      <div class="row">
+         <div class="col-lg-12 d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div class="breadcrumb-main">
+               <h4 class="text-capitalize breadcrumb-title">Enquiry Details</h4>
+            </div>
+            <a href="{{ route('seller.enquiry.list') }}" class="btn btn-outline-secondary">
+               <i class="bi bi-arrow-left-short me-1"></i>Back to List
+            </a>
+         </div>
+      </div>
+
+      <div class="row mt-3">
+         <div class="col-lg-12">
+            <div class="card shadow-sm">
+               <div class="card-body">
+                  <div class="table-responsive">
+                     <table class="table table-bordered mb-0">
+                        <tbody>
+                           <tr>
+                              <th class="w-25">Name</th>
+                              <td>{{ $query->seller_name }}</td>
+                           </tr>
+                           <tr>
+                              <th>Category Name</th>
+                              <td>{{ $query->category_name }}</td>
+                           </tr>
+                           <tr>
+                              <th>Sub Category Name</th>
+                              <td>{{ $query->sub_name }}</td>
+                           </tr>
+                           <tr>
+                              <th>Product Name</th>
+                              <td>{{ $query->product_name }}</td>
+                           </tr>
+                           <tr>
+                              <th>Brand</th>
+                              <td>{{ $query->qutation_form_product_brand }}</td>
+                           </tr>
+                           <tr>
+                              <th>Message</th>
+                              <td>{{ $query->qutation_form_message }}</td>
+                           </tr>
+                           <tr>
+                              <th>Address</th>
+                              <td>{{ $query->qutation_form_address }}</td>
+                           </tr>
+                           <tr>
+                              <th>Zipcode</th>
+                              <td>{{ $query->qutation_form_zipcode }}</td>
+                           </tr>
+                           <tr>
+                              <th>State</th>
+                              <td>{{ $query->qutation_form_state }}</td>
+                           </tr>
+                           <tr>
+                              <th>City</th>
+                              <td>{{ $query->qutation_form_city }}</td>
+                           </tr>
+                           <tr>
+                              <th>Bid Time</th>
+                              <td>{{ $query->qutation_form_bid_time }} Day</td>
+                           </tr>
+                           <tr>
+                              <th>Material</th>
+                              <td>{{ $query->qutation_form_material }}</td>
+                           </tr>
+                           <tr>
+                              <th>Quantity</th>
+                              <td>{{ $query->qutation_form_quantity }}</td>
+                           </tr>
+                           <tr>
+                              <th>Unit</th>
+                              <td>{{ $query->qutation_form_unit }}</td>
+                           </tr>
+                           <tr>
+                              <th>Profession</th>
+                              <td>{{ $query->seller_pro_ser }}</td>
+                           </tr>
+                           <tr>
+                              <th>Quotation Type</th>
+                              <td>{{ $query->qutation_form_material }}</td>
+                           </tr>
+                        </tbody>
+                     </table>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\EmailController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\Frontend\BlogController;
 use App\Http\Controllers\Frontend\AjexResponseController;
+use App\Http\Controllers\URSController\ActiveEnquiryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -135,13 +136,13 @@ Route::get('/seller/accounting/accbid', [App\Http\Controllers\SellerloginControl
 Route::get('/seller/accounting/biddrecive', [App\Http\Controllers\SellerloginController::class, 'biddrecive']);
 Route::get('/seller/accounting/list', [App\Http\Controllers\SellerloginController::class, 'accountinglist']);
 Route::get('/seller/accounting/totalshare', [App\Http\Controllers\SellerloginController::class, 'totalshare']);
-Route::get('/seller/enquiry/list', [App\Http\Controllers\SellerloginController::class, 'list']);
+Route::get('/seller/enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
 Route::get('/seller/enquiry/deactivelist', [App\Http\Controllers\SellerloginController::class, 'deactivelist']);
 Route::get('/seller/enquiry/myenclist', [App\Http\Controllers\SellerloginController::class, 'myenclist']);
 Route::post('/seller/update_lat_long', [App\Http\Controllers\SellerloginController::class, 'update_lat_long'])->name('update_lat_long');
 Route::post('/openqotationpage', [App\Http\Controllers\SellerloginController::class, 'openqotationpage'])->name('openqotationpage');
 Route::post('/bidding_price', [App\Http\Controllers\SellerloginController::class, 'bidding_price'])->name('bidding_price');
-Route::get('/seller/enquiry/view/{any}', [App\Http\Controllers\SellerloginController::class, 'vewsell']);
+Route::get('/seller/enquiry/view/{any}', [ActiveEnquiryController::class, 'show'])->name('seller.enquiry.view');
 Route::get('/seller/enquiry/file/{any}', [App\Http\Controllers\SellerloginController::class, 'vewfile']);
 Route::get('/accepet/{id}/{data_id}', [App\Http\Controllers\SellerloginController::class, 'accepet'])->name('accepet');
 Route::get('/viewwork/{id}', [App\Http\Controllers\SellerloginController::class, 'viewwork'])->name('viewwork');


### PR DESCRIPTION
## Summary
- inline the active enquiry filtering logic in the controller index method with optional category ids and AJAX partial responses
- collapse the seller enquiry routes to a single optional-id endpoint that serves both initial pages and table refreshes
- update the URS dashboard list blade to reuse the computed base URL for form submissions and asynchronous table reloads

## Testing
- php -l app/Http/Controllers/URSController/ActiveEnquiryController.php

------
https://chatgpt.com/codex/tasks/task_e_68d8556cd1ac83279191ce7826905b17