### PR TITLE
Fix category query for seller active enquiry list

### DIFF
--- a/app/Http/Controllers/URSController/ActiveEnquiryController.php
+++ b/app/Http/Controllers/URSController/ActiveEnquiryController.php
@@ -61,7 +61,7 @@ class ActiveEnquiryController extends Controller
         $blogs = $this->appendComputedState($blogs, $seller->email);
 
         $categoryData = DB::table('categories')
-            ->select('id', 'name', 'title')
+            ->select('id', 'name', DB::raw('name as title'))
             ->orderBy('name')
             ->get();
 


### PR DESCRIPTION
## Summary
- adjust the active enquiry category lookup to alias the name column as a title to match existing usage
- prevent SQL errors caused by selecting a non-existent title field on the categories table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d859552c4c83279bd0ac6c621ed03f