### PR TITLE
Align active enquiry views with dashboard styling

### DIFF
--- a/resources/views/seller/enquiry/list.blade.php
+++ b/resources/views/seller/enquiry/list.blade.php
@@ -172,6 +172,14 @@
                               <i class="bi bi-funnel-fill me-2"></i>Apply Filters
                            </button>
                         </div>
+
+                        <!-- Reset Button -->
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label d-none d-lg-block">&nbsp;</label>
+                           <a href="{{ url('seller/enquiry/list') }}" class="btn btn-outline-secondary w-100">
+                              <i class="bi bi-arrow-counterclockwise me-2"></i>Reset Filters
+                           </a>
+                        </div>
                      </form>
                   </div>
                </div>

--- a/resources/views/seller/enquiry/view.blade.php
+++ b/resources/views/seller/enquiry/view.blade.php
@@ -44,140 +44,72 @@
                <div class="col-md-12 mt-2">
                </div>
                <div class="card-body">
-                  <div class="table-responsive">
-                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
-                     {{-- Standard seller table class --}}
-                     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Name</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->seller_name }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Category Name</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->category_name }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">SubCategory Name</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->sub_name }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Product Name</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->product_name }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Brand</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_product_brand }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Message</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_message }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Address</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_address }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Zipcode</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_zipcode }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">State</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_state }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">City</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_city }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Time</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_bid_time }} Day</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Material</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_material }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Qty</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_quantity }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Unit</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_date_unit }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Profession</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->seller_pro_ser }}</span>
-                           </td>
-                        </tr>
-                        <tr class="userDatatable-header">
-                           <td>
-                              <span class="projectDatatable-title">Quotation Type</span>
-                           </td>
-                           <td>
-                              <span class="projectDatatable-title">{{ $query->qutation_form_material }}</span>
-                           </td>
-                        </tr>
-                     </table>
-                  </div>
+                  <form class="row g-3">
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name</label>
+                        <input type="text" class="form-control" value="{{ $query->seller_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Category Name</label>
+                        <input type="text" class="form-control" value="{{ $query->category_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">SubCategory Name</label>
+                        <input type="text" class="form-control" value="{{ $query->sub_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Product Name</label>
+                        <input type="text" class="form-control" value="{{ $query->product_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Brand</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_product_brand }}" readonly>
+                     </div>
+                     <div class="col-12">
+                        <label class="form-label fw-semibold">Message</label>
+                        <textarea class="form-control" rows="3" readonly>{{ $query->qutation_form_message }}</textarea>
+                     </div>
+                     <div class="col-12">
+                        <label class="form-label fw-semibold">Address</label>
+                        <textarea class="form-control" rows="2" readonly>{{ $query->qutation_form_address }}</textarea>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Zipcode</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_zipcode }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">State</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_state }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">City</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_city }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Bid Time (Days)</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_bid_time }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Material</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_material }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Quantity</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_quantity }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Unit</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_date_unit }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Profession</label>
+                        <input type="text" class="form-control" value="{{ $query->seller_pro_ser }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Quotation Type</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_material }}" readonly>
+                     </div>
+                  </form>
                </div>
             </div>
          </div>
@@ -185,3 +117,4 @@
    </div>
 </div>
 @endsection
+

--- a/resources/views/ursdashboard/active-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/list.blade.php
@@ -152,6 +152,12 @@
                               <i class="bi bi-funnel-fill me-2"></i>Apply Filters
                            </button>
                         </div>
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label d-none d-lg-block">&nbsp;</label>
+                           <button type="button" id="resetActiveEnquiryFilters" class="btn btn-outline-secondary w-100">
+                              <i class="bi bi-arrow-counterclockwise me-2"></i>Reset Filters
+                           </button>
+                        </div>
                      </form>
                   </div>
                </div>
@@ -254,6 +260,15 @@
 
       $form.on('change', '#recordsPerPage', function () {
          $form.trigger('submit');
+      });
+
+      $('#resetActiveEnquiryFilters').on('click', function () {
+         $form[0].reset();
+         $form.find('select').each(function () {
+            $(this).val('').trigger('change');
+         });
+         $form.find('input[type="text"]').val('');
+         fetchActiveEnquiries(baseUrl);
       });
 
       $(document).on('click', '#activeEnquiryTable .pagination a', function (event) {

--- a/resources/views/ursdashboard/active-enquiry/view.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/view.blade.php
@@ -17,79 +17,75 @@
       </div>
 
       <div class="row mt-3">
-         <div class="col-lg-12">
+         <div class="col-lg-12 mb-30">
             <div class="card shadow-sm">
                <div class="card-body">
-                  <div class="table-responsive">
-                     <table class="table table-bordered mb-0">
-                        <tbody>
-                           <tr>
-                              <th class="w-25">Name</th>
-                              <td>{{ $query->seller_name }}</td>
-                           </tr>
-                           <tr>
-                              <th>Category Name</th>
-                              <td>{{ $query->category_name }}</td>
-                           </tr>
-                           <tr>
-                              <th>Sub Category Name</th>
-                              <td>{{ $query->sub_name }}</td>
-                           </tr>
-                           <tr>
-                              <th>Product Name</th>
-                              <td>{{ $query->product_name }}</td>
-                           </tr>
-                           <tr>
-                              <th>Brand</th>
-                              <td>{{ $query->qutation_form_product_brand }}</td>
-                           </tr>
-                           <tr>
-                              <th>Message</th>
-                              <td>{{ $query->qutation_form_message }}</td>
-                           </tr>
-                           <tr>
-                              <th>Address</th>
-                              <td>{{ $query->qutation_form_address }}</td>
-                           </tr>
-                           <tr>
-                              <th>Zipcode</th>
-                              <td>{{ $query->qutation_form_zipcode }}</td>
-                           </tr>
-                           <tr>
-                              <th>State</th>
-                              <td>{{ $query->qutation_form_state }}</td>
-                           </tr>
-                           <tr>
-                              <th>City</th>
-                              <td>{{ $query->qutation_form_city }}</td>
-                           </tr>
-                           <tr>
-                              <th>Bid Time</th>
-                              <td>{{ $query->qutation_form_bid_time }} Day</td>
-                           </tr>
-                           <tr>
-                              <th>Material</th>
-                              <td>{{ $query->qutation_form_material }}</td>
-                           </tr>
-                           <tr>
-                              <th>Quantity</th>
-                              <td>{{ $query->qutation_form_quantity }}</td>
-                           </tr>
-                           <tr>
-                              <th>Unit</th>
-                              <td>{{ $query->qutation_form_unit }}</td>
-                           </tr>
-                           <tr>
-                              <th>Profession</th>
-                              <td>{{ $query->seller_pro_ser }}</td>
-                           </tr>
-                           <tr>
-                              <th>Quotation Type</th>
-                              <td>{{ $query->qutation_form_material }}</td>
-                           </tr>
-                        </tbody>
-                     </table>
-                  </div>
+                  <form class="row g-3">
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name</label>
+                        <input type="text" class="form-control" value="{{ $query->seller_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Category Name</label>
+                        <input type="text" class="form-control" value="{{ $query->category_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Sub Category Name</label>
+                        <input type="text" class="form-control" value="{{ $query->sub_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Product Name</label>
+                        <input type="text" class="form-control" value="{{ $query->product_name }}" readonly>
+                     </div>
+                     <div class="col-md-6">
+                        <label class="form-label fw-semibold">Brand</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_product_brand }}" readonly>
+                     </div>
+                     <div class="col-12">
+                        <label class="form-label fw-semibold">Message</label>
+                        <textarea class="form-control" rows="3" readonly>{{ $query->qutation_form_message }}</textarea>
+                     </div>
+                     <div class="col-12">
+                        <label class="form-label fw-semibold">Address</label>
+                        <textarea class="form-control" rows="2" readonly>{{ $query->qutation_form_address }}</textarea>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Zipcode</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_zipcode }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">State</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_state }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">City</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_city }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Bid Time (Days)</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_bid_time }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Material</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_material }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Quantity</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_quantity }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Unit</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_unit }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Profession</label>
+                        <input type="text" class="form-control" value="{{ $query->seller_pro_ser }}" readonly>
+                     </div>
+                     <div class="col-md-4">
+                        <label class="form-label fw-semibold">Quotation Type</label>
+                        <input type="text" class="form-control" value="{{ $query->qutation_form_material }}" readonly>
+                     </div>
+                  </form>
                </div>
             </div>
          </div>


### PR DESCRIPTION
## Summary
- refactor the active enquiry detail view to use the Bootstrap form-style layout for clearer presentation
- add a Reset Filters button to the active enquiry list and hook it into the existing AJAX refresh flow

## Testing
- not run (dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d85a4344d4832798a5b262bd9988ec