### PR TITLE
Show quotation IDs on seller enquiry list

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use App\Models\User;
 use App\Models\Category;
 use Illuminate\Support\Facades\File;
@@ -358,6 +357,7 @@ class HomeController extends Controller
         $sellerIds = $sellers->pluck('id')->implode(',');
 
         $data = [
+            'qutation_id'  => $this->generateUniqueQuotationId(),
             'latitude'      => $latitude,
             'longitude'     => $longitude,
             'name'          => $request->name,
@@ -398,6 +398,24 @@ class HomeController extends Controller
         } else {
             return back()->withErrors(['error' => 'Insertion Failed.'])->withInput();
         }
+    }
+
+    private function generateUniqueQuotationId(): string
+    {
+        $prefix = 'URSBID-';
+        $length = 10;
+        $characters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+        do {
+            $randomString = '';
+            for ($i = 0; $i < $length; $i++) {
+                $randomString .= $characters[random_int(0, strlen($characters) - 1)];
+            }
+
+            $quotationId = $prefix . $randomString;
+        } while (DB::table('qutation_form')->where('qutation_id', $quotationId)->exists());
+
+        return $quotationId;
     }
 
     public function rating(Request $request)

--- a/app/Http/Controllers/URSController/ActiveEnquiryController.php
+++ b/app/Http/Controllers/URSController/ActiveEnquiryController.php
@@ -181,6 +181,7 @@ class ActiveEnquiryController extends Controller
             ->whereRaw('DATE_ADD(date_time, INTERVAL bid_time DAY) >= ?', [$currentDate])
             ->select(
                 'qutation_form.id as id',
+                'qutation_form.qutation_id as qutation_id',
                 'qutation_form.name as name',
                 'qutation_form.email as email',
                 'qutation_form.product_id as qutation_form_product_id',

--- a/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
@@ -3,6 +3,7 @@
       <thead>
          <tr>
             <th>Sr no</th>
+            <th>Quotation ID</th>
             <th>Name</th>
             <th>Category</th>
             <th>Sub Category</th>
@@ -20,6 +21,7 @@
          @forelse ($blogs as $index => $blog)
             <tr>
                <td>{{ ($blogs->currentPage() - 1) * $blogs->perPage() + $index + 1 }}</td>
+               <td>{{ $blog->qutation_id ?? '-' }}</td>
                <td>{{ $blog->name }}</td>
                <td>{{ $blog->category_name }}</td>
                <td>{{ $blog->sub_name }}</td>
@@ -65,7 +67,7 @@
             </tr>
          @empty
             <tr>
-               <td colspan="12" class="text-center py-4">No enquiries found.</td>
+               <td colspan="13" class="text-center py-4">No enquiries found.</td>
             </tr>
          @endforelse
       </tbody>


### PR DESCRIPTION
## Summary
- include each quotation's URSBID identifier in the active enquiry dataset for sellers
- display the quotation ID column on the seller active enquiry table

## Testing
- php -l app/Http/Controllers/URSController/ActiveEnquiryController.php

------
https://chatgpt.com/codex/tasks/task_e_68da1d5b3c488327b2dbb2a06f3ba942