### PR TITLE
Update active enquiry filters and date format

### DIFF
--- a/resources/views/ursdashboard/active-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/list.blade.php
@@ -138,6 +138,11 @@
                         </div>
 
                         <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label class="form-label">Quotation ID</label>
+                           <input type="text" name="qutation_id" id="filterQuotationId" class="form-control" placeholder="Quotation ID" value="{{ $data['qutation_id'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
                            <label class="form-label">Records Per Page</label>
                            <select name="r_page" id="recordsPerPage" class="form-select">
                               <option value="25" {{ $data['r_page'] == 25 ? 'selected' : '' }}>25</option>

--- a/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
@@ -27,7 +27,7 @@
                <td>{{ $blog->sub_name }}</td>
                <td>{{ $blog->product_name }}</td>
                <td>{{ $blog->bid_time }} day</td>
-               <td>{{ $blog->date_time ? \Carbon\Carbon::parse($blog->date_time)->format('Y-m-d') : '-' }}</td>
+               <td>{{ $blog->date_time ? \Carbon\Carbon::parse($blog->date_time)->format('d-m-Y') : '-' }}</td>
                <td>{{ $blog->quantity }}</td>
                <td>{{ $blog->unit }}</td>
                <td>


### PR DESCRIPTION
## Summary
- collapse product brand joins to a single row when listing seller enquiries
- reuse the deduplicated brand join when showing a single enquiry
- add a quotation ID filter to the seller active enquiry list
- display active enquiry dates in dd-mm-yyyy format

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da207a320883279f6243a9bb55fe13