### PR TITLE
Extract bidding modal into reusable partial

### DIFF
--- a/resources/views/ursdashboard/active-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/list.blade.php
@@ -18,57 +18,7 @@
          </div>
       </div>
 
-      <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-         <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-               <div class="modal-header">
-                  <h5 class="modal-title">Bidding Price</h5>
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-               </div>
-               <div class="modal-body">
-                  <form action="{{ url('/openqotationpage') }}" method="POST" enctype="multipart/form-data">
-                     @csrf
-                     <input type="hidden" name="seller_email" value="{{ $sellerEmail }}">
-                     <input type="hidden" name="product_id" class="product_id form-control">
-                     <input type="hidden" name="product_quantity" class="product_quantity form-control">
-                     <input type="hidden" name="product_name" class="product_name form-control">
-                     <input type="hidden" name="user_email" class="user_email form-control">
-                     <input type="hidden" name="data_id" class="data_id form-control">
-
-                     <div class="d-flex gap-3">
-                        <div class="flex-grow-1">
-                           <label class="font-weight-bold">Enter Price</label>
-                           <input type="number" name="price" required class="price form-control" placeholder="Enter Price" min="1">
-                        </div>
-                        <div>
-                           <label class="font-weight-bold">Quantity</label>
-                           <input readonly class="product_quantity form-control">
-                        </div>
-                     </div>
-
-                     <div class="d-flex justify-content-between mt-3 gap-3 flex-wrap">
-                        <div class="d-flex align-items-center">
-                           <span class="font-weight-bold">Total :- </span>
-                           <span class="total ms-2">0.00</span>
-                        </div>
-                        <div class="flex-grow-1">
-                           <label class="font-weight-bold">Quotation file (optional)</label>
-                           <input type="file" name="file" class="form-control">
-                        </div>
-                     </div>
-
-                     <div class="d-flex mt-3 align-items-center">
-                        <input type="checkbox" id="myCheckbox" required>
-                        <span class="ms-2">I accept all the</span>&nbsp;
-                        <a href="#!" class="exampleModalCentersmall" data-bs-toggle="modal" data-bs-target="#exampleModalCentersmall">agreement terms & condition</a>
-                     </div>
-
-                     <button type="submit" class="btn btn-primary mt-3">Submit</button>
-                  </form>
-               </div>
-            </div>
-         </div>
-      </div>
+      @include('ursdashboard.active-enquiry.partials.bidding-modal', ['sellerEmail' => $sellerEmail])
 
       <div class="modal fade" id="exampleModalCentersmall" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
          <div class="modal-dialog modal-dialog-centered" role="document">
@@ -283,9 +233,14 @@
          }
       });
 
-      $(document).on('click', '#activeEnquiryTable .mdl_btn', function () {
+      $(document).on('click', '.js-open-bidding-modal', function () {
          const $btn = $(this);
-         const $modal = $('#exampleModalCenter');
+         const modalSelector = $btn.attr('data-bs-target') || '#exampleModalCenter';
+         const $modal = $(modalSelector);
+
+         if (!$modal.length) {
+            return;
+         }
 
          $modal.find('.product_quantity').val($btn.data('product-quantity'));
          $modal.find('.product_id').val($btn.data('product-id'));

--- a/resources/views/ursdashboard/active-enquiry/partials/bidding-modal.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/bidding-modal.blade.php
@@ -1,0 +1,51 @@
+<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+   <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="modal-content">
+         <div class="modal-header">
+            <h5 class="modal-title">Bidding Price</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+         </div>
+         <div class="modal-body">
+            <form action="{{ url('/openqotationpage') }}" method="POST" enctype="multipart/form-data">
+               @csrf
+               <input type="hidden" name="seller_email" value="{{ $sellerEmail }}">
+               <input type="hidden" name="product_id" class="product_id form-control">
+               <input type="hidden" name="product_quantity" class="product_quantity form-control">
+               <input type="hidden" name="product_name" class="product_name form-control">
+               <input type="hidden" name="user_email" class="user_email form-control">
+               <input type="hidden" name="data_id" class="data_id form-control">
+
+               <div class="d-flex gap-3">
+                  <div class="flex-grow-1">
+                     <label class="font-weight-bold">Enter Price</label>
+                     <input type="number" name="price" required class="price form-control" placeholder="Enter Price" min="1">
+                  </div>
+                  <div>
+                     <label class="font-weight-bold">Quantity</label>
+                     <input readonly class="product_quantity form-control">
+                  </div>
+               </div>
+
+               <div class="d-flex justify-content-between mt-3 gap-3 flex-wrap">
+                  <div class="d-flex align-items-center">
+                     <span class="font-weight-bold">Total :- </span>
+                     <span class="total ms-2">0.00</span>
+                  </div>
+                  <div class="flex-grow-1">
+                     <label class="font-weight-bold">Quotation file (optional)</label>
+                     <input type="file" name="file" class="form-control">
+                  </div>
+               </div>
+
+               <div class="d-flex mt-3 align-items-center">
+                  <input type="checkbox" id="myCheckbox" required>
+                  <span class="ms-2">I accept all the</span>&nbsp;
+                  <a href="#!" class="exampleModalCentersmall" data-bs-toggle="modal" data-bs-target="#exampleModalCentersmall">agreement terms & condition</a>
+               </div>
+
+               <button type="submit" class="btn btn-primary mt-3">Submit</button>
+            </form>
+         </div>
+      </div>
+   </div>
+</div>

--- a/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
@@ -48,7 +48,7 @@
                         <i class="bi bi-eye me-1"></i>View
                      </a>
                      @if($blog->show_bidding_button)
-                        <a href="#!" class="btn btn-outline-primary btn-sm"
+                        <a href="#!" class="btn btn-outline-primary btn-sm js-open-bidding-modal"
                            data-bs-toggle="modal" data-bs-target="#exampleModalCenter"
                            data-product-id="{{ $blog->product_id }}"
                            data-product-quantity="{{ $blog->quantity }}"


### PR DESCRIPTION
## Summary
- move the bidding price modal markup into a dedicated partial for reuse and easier maintenance
- adjust the active enquiry list to include the new partial and prepare the modal data via a delegated handler
- tag the bidding action button with a specific class so Ajax-refreshed tables continue to populate the modal correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da273c9ca4832795dff2f31e1e0a31