### PR TITLE
Load bidding modal data via AJAX

### DIFF
--- a/app/Http/Controllers/URSController/ActiveEnquiryController.php
+++ b/app/Http/Controllers/URSController/ActiveEnquiryController.php
@@ -177,6 +177,31 @@ class ActiveEnquiryController extends Controller
         ]);
     }
 
+    public function biddingData(Request $request, $id)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (!$seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        $enquiry = $this->baseActiveEnquiryQuery($seller->id, $seller->email)
+            ->where('qutation_form.id', $id)
+            ->first();
+
+        if (!$enquiry) {
+            return response()->json(['message' => 'Enquiry not found.'], 404);
+        }
+
+        return response()->json([
+            'data_id' => $enquiry->id,
+            'product_id' => $enquiry->product_id,
+            'product_name' => $enquiry->product_name,
+            'product_quantity' => $enquiry->quantity,
+            'user_email' => $enquiry->email,
+        ]);
+    }
+
     protected function baseActiveEnquiryQuery($sellerId, string $sellerEmail)
     {
         $currentDate = Carbon::now();

--- a/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/partials/table.blade.php
@@ -49,12 +49,7 @@
                      </a>
                      @if($blog->show_bidding_button)
                         <a href="#!" class="btn btn-outline-primary btn-sm js-open-bidding-modal"
-                           data-bs-toggle="modal" data-bs-target="#exampleModalCenter"
-                           data-product-id="{{ $blog->product_id }}"
-                           data-product-quantity="{{ $blog->quantity }}"
-                           data-product-name="{{ $blog->product_name }}"
-                           data-data-id="{{ $blog->id }}"
-                           data-user-email="{{ $blog->email }}">
+                           data-enquiry-id="{{ $blog->id }}">
                            <i class="bi bi-gavel me-1"></i>Bidding
                         </a>
                      @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -137,6 +137,7 @@ Route::get('/seller/accounting/biddrecive', [App\Http\Controllers\SellerloginCon
 Route::get('/seller/accounting/list', [App\Http\Controllers\SellerloginController::class, 'accountinglist']);
 Route::get('/seller/accounting/totalshare', [App\Http\Controllers\SellerloginController::class, 'totalshare']);
 Route::get('/seller/enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
+Route::get('/seller/enquiry/bidding-data/{id}', [ActiveEnquiryController::class, 'biddingData'])->name('seller.enquiry.bidding-data');
 Route::get('/seller/enquiry/deactivelist', [App\Http\Controllers\SellerloginController::class, 'deactivelist']);
 Route::get('/seller/enquiry/myenclist', [App\Http\Controllers\SellerloginController::class, 'myenclist']);
 Route::post('/seller/update_lat_long', [App\Http\Controllers\SellerloginController::class, 'update_lat_long'])->name('update_lat_long');


### PR DESCRIPTION
## Summary
- add a dedicated endpoint for retrieving enquiry details needed by the bidding modal
- update the active enquiry table buttons to stop embedding product details as data attributes
- fetch bidding information over AJAX when opening the modal and populate the form dynamically

## Testing
- php -l app/Http/Controllers/URSController/ActiveEnquiryController.php

------
https://chatgpt.com/codex/tasks/task_e_68da2a80a80c8327a3eeae3d7e154409