### PR TITLE
Fix seller deactivelist category label

### DIFF
--- a/resources/views/seller/enquiry/deactivelist.blade.php
+++ b/resources/views/seller/enquiry/deactivelist.blade.php
@@ -57,7 +57,7 @@
                               <option value="">Select Category</option>
                               @foreach($category_data as $cat)
                               <option value="{{ $cat->id }}" {{ $data['category'] == $cat->id ? 'selected' : '' }}>
-                              {{ $cat->title }}</option>
+                              {{ $cat->name }}</option>
                               @endforeach
                            </select>
                         </div>


### PR DESCRIPTION
## Summary
- update the closed enquiry category dropdown to use the category name field instead of the nonexistent title property

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da37899d5c8327b42a568014029b4f