### PR TITLE
Fix category title access in seller enquiry filter

### DIFF
--- a/resources/views/seller/enquiry/myenclist.blade.php
+++ b/resources/views/seller/enquiry/myenclist.blade.php
@@ -104,7 +104,7 @@
                               <option value="">Select Category</option>
                               @foreach($category_data as $cat)
                               <option value="{{ $cat->id }}" {{ $data['category'] == $cat->id ? 'selected' : '' }}>
-                              {{ $cat->title }}
+                              {{ $cat->name ?? $cat->title ?? '' }}
                               </option>
                               @endforeach
                            </select>


### PR DESCRIPTION
## Summary
- ensure the seller enquiry list category dropdown gracefully handles categories without a title property

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da41d95ce88327a7d3a8f2acb65020