### PR TITLE
Fix undefined category title property on bidding received page

### DIFF
--- a/resources/views/seller/accounting/biddrecive.blade.php
+++ b/resources/views/seller/accounting/biddrecive.blade.php
@@ -61,7 +61,7 @@
                                     <option value="">Select Category</option>
                                     @foreach($category_data as $cat)
                                     <option value="{{ $cat->id }}" {{ ($datas['category'] ?? '') == $cat->id ? 'selected' : '' }}>
-                                        {{ $cat->title }}
+                                        {{ $cat->name }}
                                     </option>
                                     @endforeach
                                 </select>


### PR DESCRIPTION
## Summary
- display category names in the bidding received filter dropdown using the existing name field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da42bf75288327b1db577241469144