### PR TITLE
Fix category selection display for seller accounting list

### DIFF
--- a/resources/views/seller/accounting/list.blade.php
+++ b/resources/views/seller/accounting/list.blade.php
@@ -61,7 +61,7 @@
                                     <option value="">Select Category</option>
                                     @foreach($category_data as $cat)
                                     <option value="{{ $cat->id }}" {{ ($datas['category'] ?? '') == $cat->id ? 'selected' : '' }}>
-                                        {{ $cat->title }}
+                                        {{ $cat->name }}
                                     </option>
                                     @endforeach
                                 </select>


### PR DESCRIPTION
## Summary
- update the seller accounting list filter to read the category name field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da43c427ac8327a9e100f0982c172a