### PR TITLE
Ensure categories expose title attribute

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -39,7 +39,9 @@ class HomeController extends Controller
         $quantity     = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data  = DB::table('categories')->get();
+        $category_data  = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
         $query = DB::table('bidding_price')
@@ -591,7 +593,9 @@ class HomeController extends Controller
         $product_name = $request->input('product_name');
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
 
         $query = DB::table('qutation_form')
             ->leftJoin('seller', 'qutation_form.email', '=', 'seller.email')
@@ -708,7 +712,9 @@ class HomeController extends Controller
         $product_name = $request->input('product_name');
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
 
         $query = DB::table('qutation_form')
             ->leftJoin('seller', 'qutation_form.email', '=', 'seller.email')
@@ -1036,7 +1042,9 @@ class HomeController extends Controller
         $quantity     = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data  = DB::table('categories')->get();
+        $category_data  = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
         $data = DB::table('bidding_price')
@@ -1165,7 +1173,9 @@ class HomeController extends Controller
         $quantity     = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data  = DB::table('categories')->get();
+        $category_data  = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
         $data = DB::table('bidding_price')

--- a/app/Http/Controllers/SellerloginController.php
+++ b/app/Http/Controllers/SellerloginController.php
@@ -446,7 +446,9 @@ class SellerloginController extends Controller
         $quantity = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
 
@@ -573,7 +575,9 @@ class SellerloginController extends Controller
         $quantity = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
 
@@ -632,7 +636,9 @@ class SellerloginController extends Controller
         $product_name = $request->input('product_name');
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
 
         // $query = DB::table('qutation_form')
         //     ->whereRaw("FIND_IN_SET(?, seller_id)", [$sellerId])
@@ -760,7 +766,9 @@ class SellerloginController extends Controller
         $product_name = $request->input('product_name');
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $selleremail = $request->session()->get('seller')->email;
 
         $query = DB::table('qutation_form')
@@ -1199,7 +1207,9 @@ class SellerloginController extends Controller
         $quantity = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
 
@@ -1339,7 +1349,9 @@ class SellerloginController extends Controller
         $quantity = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
         $query = DB::table('bidding_price')
@@ -1479,7 +1491,9 @@ class SellerloginController extends Controller
         $quantity = $request->input('quantity');
         $product_name = $request->input('product_name');
 
-        $category_data = DB::table('categories')->get();
+        $category_data = DB::table('categories')
+            ->select('categories.*', 'categories.name as title')
+            ->get();
         $recordsPerPage = $request->input('r_page', 25);
 
         $query = DB::table('bidding_price')


### PR DESCRIPTION
## Summary
- alias category name to title for seller accounting flows to match view expectations
- apply the same alias across seller and admin controllers that provide category_data collections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da447e97e48327b120666c4ca7f2ab