### PR TITLE
Add quotation ID filter to seller enquiry list

### DIFF
--- a/app/Http/Controllers/SellerloginController.php
+++ b/app/Http/Controllers/SellerloginController.php
@@ -763,6 +763,7 @@ class SellerloginController extends Controller
         $date = $request->input('date');
         $city = $request->input('city');
         $quantity = $request->input('quantity');
+        $qutationId = $request->input('qutation_id');
         $product_name = $request->input('product_name');
         $recordsPerPage = $request->input('r_page', 15);
         $currentDate = \Carbon\Carbon::now();
@@ -780,8 +781,8 @@ class SellerloginController extends Controller
             ->leftJoin('categories as c', 'sc.category_id', '=', 'c.id')
             ->where('qutation_form.email', $selleremail)
             ->select(
-            
                 'qutation_form.id as id',
+                'qutation_form.id as qutation_id',
                 'qutation_form.name as name',
                 'qutation_form.email as email',
                 'qutation_form.product_id as qutation_form_product_id',
@@ -863,6 +864,9 @@ class SellerloginController extends Controller
         if ($quantity) {
             $query->where('qutation_form.quantity', 'like', '%' . $quantity . '%');
         }
+        if ($qutationId) {
+            $query->where('qutation_form.id', 'like', '%' . $qutationId . '%');
+        }
         if ($product_name) {
             $query->where('product.title', 'like', '%' . $product_name . '%');
         }
@@ -876,6 +880,7 @@ class SellerloginController extends Controller
             'category' => $category,
             'product_name' => $product_name,
             'r_page' => $recordsPerPage,
+            'qutation_id' => $qutationId,
         ];
 
         return view('seller.enquiry.myenclist', compact('blogs', 'data', 'category_data'));

--- a/resources/views/seller/enquiry/myenclist.blade.php
+++ b/resources/views/seller/enquiry/myenclist.blade.php
@@ -110,6 +110,11 @@
                            </select>
                         </div>
                         <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
+                           <label for="myQuotationId" class="form-label">Quotation ID</label>
+                           <input type="text" id="myQuotationId" name="qutation_id" class="form-control" placeholder="Quotation ID"
+                              value="{{ isset($data['qutation_id']) ? $data['qutation_id'] : '' }}">
+                        </div>
+                        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
                            <label for="myDate" class="form-label">Date</label>
                            <input type="text" id="myDate" name="date" class="form-control" placeholder="Date"
                               value="{{ isset($data['date']) ? $data['date'] : '' }}">
@@ -140,9 +145,14 @@
                         </div>
                         <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
                            <label class="form-label d-none d-lg-block">&nbsp;</label>
-                           <button type="submit" class="btn btn-primary w-100">
-                           <i class="bi bi-funnel-fill me-2"></i>Apply Filters
-                           </button>
+                           <div class="d-flex gap-2 flex-wrap">
+                              <button type="submit" class="btn btn-primary flex-fill">
+                              <i class="bi bi-funnel-fill me-2"></i>Apply Filters
+                              </button>
+                              <a href="{{ url('seller/enquiry/myenclist') }}" class="btn btn-outline-secondary flex-fill">
+                                 Reset
+                              </a>
+                           </div>
                         </div>
                      </form>
                   </div>
@@ -180,6 +190,9 @@
                            <tr class="userDatatable-header">
                               <th>
                                  <span class="projectDatatable-title">Sr no</span>
+                              </th>
+                              <th>
+                                 <span class="projectDatatable-title">Quotation ID</span>
                               </th>
                               <th>
                                  <span class="projectDatatable-title">Name</span>
@@ -239,6 +252,11 @@
                               <td>
                                  <div class="userDatatable-content text-center">
                                     {{ $i++ }}
+                                 </div>
+                              </td>
+                              <td>
+                                 <div class="userDatatable-content">
+                                    {{ $blog->qutation_id }}
                                  </div>
                               </td>
                               <td>


### PR DESCRIPTION
## Summary
- add support for filtering seller enquiry records by quotation ID in the controller
- expose the quotation ID input and a reset action in the My Enquiry List filter form
- surface each enquiry's quotation ID in the results table for quicker reference

## Testing
- php artisan serve *(fails: missing vendor autoload due to incompatible PHP version for locked dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68da4680e9fc8327876167ebd73139aa