### PR TITLE
Use quotation_id for seller enquiry filters

### DIFF
--- a/app/Http/Controllers/SellerloginController.php
+++ b/app/Http/Controllers/SellerloginController.php
@@ -782,7 +782,7 @@ class SellerloginController extends Controller
             ->where('qutation_form.email', $selleremail)
             ->select(
                 'qutation_form.id as id',
-                'qutation_form.id as qutation_id',
+                'qutation_form.qutation_id as qutation_id',
                 'qutation_form.name as name',
                 'qutation_form.email as email',
                 'qutation_form.product_id as qutation_form_product_id',
@@ -865,7 +865,7 @@ class SellerloginController extends Controller
             $query->where('qutation_form.quantity', 'like', '%' . $quantity . '%');
         }
         if ($qutationId) {
-            $query->where('qutation_form.id', 'like', '%' . $qutationId . '%');
+            $query->where('qutation_form.qutation_id', 'like', '%' . $qutationId . '%');
         }
         if ($product_name) {
             $query->where('product.title', 'like', '%' . $product_name . '%');


### PR DESCRIPTION
## Summary
- select the actual quotation identifier from qutation_form for the seller enquiry list
- filter seller enquiries by qutation_form.qutation_id instead of the primary key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4af8f3ec8327a5cfd8c62329f9e5