### PR TITLE
Add My Enquiry controller and dashboard views

### DIFF
--- a/app/Http/Controllers/URSController/MyEnquiryController.php
+++ b/app/Http/Controllers/URSController/MyEnquiryController.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Http\Controllers\URSController;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class MyEnquiryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (!$seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        $perPage = (int) $request->input('r_page', 25);
+
+        $filters = [
+            'category' => $request->input('category'),
+            'date' => $request->input('date'),
+            'city' => $request->input('city'),
+            'quantity' => $request->input('quantity'),
+            'product_name' => $request->input('product_name'),
+            'qutation_id' => $request->input('qutation_id'),
+            'r_page' => $perPage,
+        ];
+
+        $query = $this->baseMyEnquiryQuery($seller->email);
+
+        if ($request->filled('category')) {
+            $query->where('c.id', $request->input('category'));
+        }
+
+        if ($request->filled('date')) {
+            $query->where('qutation_form.date_time', 'like', '%' . $request->input('date') . '%');
+        }
+
+        if ($request->filled('city')) {
+            $query->where('qutation_form.city', 'like', '%' . $request->input('city') . '%');
+        }
+
+        if ($request->filled('quantity')) {
+            $query->where('qutation_form.quantity', 'like', '%' . $request->input('quantity') . '%');
+        }
+
+        if ($request->filled('product_name')) {
+            $query->where('product.title', 'like', '%' . $request->input('product_name') . '%');
+        }
+
+        if ($request->filled('qutation_id')) {
+            $query->where('qutation_form.qutation_id', 'like', '%' . $request->input('qutation_id') . '%');
+        }
+
+        $blogs = $query
+            ->orderByDesc('qutation_form.id')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        $blogs = $this->appendComputedState($blogs);
+
+        $categoryData = DB::table('categories')
+            ->select('id', 'name', DB::raw('name as title'))
+            ->orderBy('name')
+            ->get();
+
+        if ($request->ajax()) {
+            return view('ursdashboard.my-enquiry.partials.table', [
+                'blogs' => $blogs,
+            ])->render();
+        }
+
+        return view('ursdashboard.my-enquiry.list', [
+            'blogs' => $blogs,
+            'data' => $filters,
+            'category_data' => $categoryData,
+        ]);
+    }
+
+    protected function baseMyEnquiryQuery(string $sellerEmail)
+    {
+        $productBrands = DB::table('product_brands')
+            ->select('product_id', DB::raw('MAX(brand_name) as brand_name'))
+            ->groupBy('product_id');
+
+        return DB::table('qutation_form')
+            ->leftJoin('seller', 'qutation_form.email', '=', 'seller.email')
+            ->leftJoin('product', 'qutation_form.product_id', '=', 'product.id')
+            ->leftJoinSub($productBrands, 'pb', function ($join) {
+                $join->on('product.id', '=', 'pb.product_id');
+            })
+            ->leftJoin('sub_categories as sc', 'product.sub_id', '=', 'sc.id')
+            ->leftJoin('categories as c', 'sc.category_id', '=', 'c.id')
+            ->where('qutation_form.email', $sellerEmail)
+            ->select(
+                'qutation_form.id as id',
+                'qutation_form.qutation_id as qutation_id',
+                'qutation_form.name as name',
+                'qutation_form.email as email',
+                'qutation_form.product_id as qutation_form_product_id',
+                'qutation_form.product_img as qutation_form_product_img',
+                'qutation_form.product_name as qutation_form_product_name',
+                'pb.brand_name as qutation_form_product_brand',
+                'qutation_form.message as qutation_form_message',
+                'qutation_form.location as qutation_form_location',
+                'qutation_form.address as qutation_form_address',
+                'qutation_form.zipcode as qutation_form_zipcode',
+                'qutation_form.state as qutation_form_state',
+                'qutation_form.city as qutation_form_city',
+                'qutation_form.bid_area as qutation_form_bid_area',
+                'qutation_form.date_time as date_time',
+                'qutation_form.bid_time as bid_time',
+                'qutation_form.material as qutation_form_material',
+                'qutation_form.image as qutation_form_image',
+                'qutation_form.latitude as qutation_form_latitude',
+                'qutation_form.longitude as qutation_form_longitude',
+                'qutation_form.seller_id as qutation_form_seller_id',
+                'qutation_form.unit as unit',
+                'qutation_form.quantity as quantity',
+                'qutation_form.status as qutation_form_status',
+                'seller.id as seller_id',
+                'seller.email as seller_email',
+                'seller.name as seller_name',
+                'seller.phone as seller_phone',
+                'seller.hash_id as seller_hash_id',
+                'seller.pro_ser as seller_pro_ser',
+                'product.id as product_id',
+                'product.title as product_name',
+                'product.sub_id as product_sub_id',
+                'product.user_id as product_user_id',
+                'product.cat_id as product_cat_id',
+                'product.super_id as product_super_id',
+                'product.description as product_description',
+                'product.image as product_image',
+                'product.user_type as product_user_type',
+                'product.insert_by as product_insert_by',
+                'product.update_by as product_update_by',
+                'product.slug as product_slug',
+                'product.status as product_status',
+                'product.order_by as product_order_by',
+                'sc.id as sub_id',
+                'sc.name as sub_name',
+                'sc.category_id as sub_cat_id',
+                'sc.created_at as sub_created_at',
+                'sc.image as sub_image',
+                'sc.slug as sub_slug',
+                'sc.status as sub_status',
+                'sc.order_by as sub_order_by',
+                'c.id as category_id',
+                'c.name as category_name',
+                'c.created_at as category_created_at',
+                'c.image as category_image',
+                'c.slug as category_slug',
+                'c.status as category_status'
+            );
+    }
+
+    protected function appendComputedState(LengthAwarePaginator $blogs): LengthAwarePaginator
+    {
+        $currentDate = Carbon::now();
+        $collection = $blogs->getCollection();
+
+        $collection->transform(function ($blog) use ($currentDate) {
+            $status = 'active';
+
+            if (!empty($blog->date_time) && !empty($blog->bid_time)) {
+                $expirationDate = Carbon::parse($blog->date_time)->addDays((int) $blog->bid_time);
+
+                if ($currentDate->greaterThanOrEqualTo($expirationDate)) {
+                    $status = 'deactive';
+                }
+            }
+
+            $blog->status_badge = $status;
+
+            return $blog;
+        });
+
+        return $blogs;
+    }
+}

--- a/resources/views/ursdashboard/my-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/my-enquiry/list.blade.php
@@ -1,0 +1,139 @@
+@extends('seller.layouts.app')
+@section('title', 'My Enquiry List')
+
+@section('content')
+<div class="container-fluid">
+   <div class="social-dash-wrap">
+      <div class="row">
+         <div class="col-lg-12">
+            <div class="breadcrumb-main">
+               <h4 class="text-capitalize breadcrumb-title">My Enquiry List</h4>
+            </div>
+         </div>
+      </div>
+
+      <div class="row">
+         <div class="col-lg-12 mb-30">
+            <div class="card mb-4 shadow-sm">
+               <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                  <h5 class="mb-0">Filter My Enquiries</h5>
+                  <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="collapse" data-bs-target="#myEnquiryFilters" aria-expanded="true" aria-controls="myEnquiryFilters">
+                     Toggle Filters
+                  </button>
+               </div>
+
+               <div class="collapse show" id="myEnquiryFilters">
+                  <div class="card-body">
+                     <form id="myEnquiryFiltersForm" class="row g-3 align-items-end" method="get" action="{{ route('seller.enquiry.my-enquiry') }}">
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myCategory" class="form-label">Category</label>
+                           <select name="category" id="myCategory" class="form-select">
+                              <option value="">Select Category</option>
+                              @foreach($category_data as $cat)
+                                 <option value="{{ $cat->id }}" {{ ($data['category'] ?? null) == $cat->id ? 'selected' : '' }}>
+                                    {{ $cat->name ?? $cat->title ?? '' }}
+                                 </option>
+                              @endforeach
+                           </select>
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myQuotationId" class="form-label">Quotation ID</label>
+                           <input type="text" id="myQuotationId" name="qutation_id" class="form-control" placeholder="Quotation ID" value="{{ $data['qutation_id'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myDate" class="form-label">Date</label>
+                           <input type="text" id="myDate" name="date" class="form-control" placeholder="Date" value="{{ $data['date'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myCity" class="form-label">City</label>
+                           <input type="text" id="myCity" name="city" class="form-control" placeholder="City" value="{{ $data['city'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myQuantity" class="form-label">Quantity</label>
+                           <input type="text" id="myQuantity" name="quantity" class="form-control" placeholder="Quantity" value="{{ $data['quantity'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myProduct" class="form-label">Product Name</label>
+                           <input type="text" id="myProduct" name="product_name" class="form-control" placeholder="Product Name" value="{{ $data['product_name'] ?? '' }}">
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label for="myPerPage" class="form-label">Records Per Page</label>
+                           <select class="form-select" id="myPerPage" name="r_page">
+                              <option value="25" {{ ($data['r_page'] ?? 25) == 25 ? 'selected' : '' }}>25</option>
+                              <option value="50" {{ ($data['r_page'] ?? 25) == 50 ? 'selected' : '' }}>50</option>
+                              <option value="100" {{ ($data['r_page'] ?? 25) == 100 ? 'selected' : '' }}>100</option>
+                           </select>
+                        </div>
+
+                        <div class="col-12 col-sm-6 col-lg-3">
+                           <label class="form-label d-none d-lg-block">&nbsp;</label>
+                           <div class="d-flex flex-column flex-sm-row flex-lg-column flex-xl-row gap-2">
+                              <button type="submit" class="btn btn-primary w-100 flex-fill">
+                                 <i class="bi bi-funnel-fill me-2"></i>Apply Filters
+                              </button>
+                              <button type="button" id="resetMyEnquiryFilters" class="btn btn-outline-secondary w-100 flex-fill">
+                                 <i class="bi bi-arrow-counterclockwise me-2"></i>Reset
+                              </button>
+                           </div>
+                        </div>
+                     </form>
+                  </div>
+               </div>
+            </div>
+
+            @if(Session::has('success'))
+               <div class="alert alert-success alert-dismissible fade show">
+                  {{ Session::get('success') }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            @if(Session::has('error'))
+               <div class="alert alert-danger alert-dismissible fade show">
+                  {{ Session::get('error') }}
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            @if ($errors->any())
+               <div class="alert alert-danger alert-dismissible fade show">
+                  <ul class="mb-0">
+                     @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                     @endforeach
+                  </ul>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+               </div>
+            @endif
+
+            <div class="card shadow-sm">
+               <div class="card-body">
+                  <div id="myEnquiryTable">
+                     @include('ursdashboard.my-enquiry.partials.table', ['blogs' => $blogs])
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>
+
+<script>
+   (function () {
+      const resetButton = document.getElementById('resetMyEnquiryFilters');
+      const filtersForm = document.getElementById('myEnquiryFiltersForm');
+
+      if (resetButton && filtersForm) {
+         resetButton.addEventListener('click', function () {
+            window.location.href = filtersForm.getAttribute('action');
+         });
+      }
+   })();
+</script>
+@endsection

--- a/resources/views/ursdashboard/my-enquiry/partials/table.blade.php
+++ b/resources/views/ursdashboard/my-enquiry/partials/table.blade.php
@@ -1,0 +1,58 @@
+<div class="table-responsive">
+   <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+      <thead>
+         <tr>
+            <th>Sr no</th>
+            <th>Quotation ID</th>
+            <th>Name</th>
+            <th>Category</th>
+            <th>Sub Category</th>
+            <th>Product Name</th>
+            <th>Time</th>
+            <th>Date</th>
+            <th>Quantity</th>
+            <th>Unit</th>
+            <th>Quotation</th>
+            <th>Status</th>
+         </tr>
+      </thead>
+      <tbody>
+         @forelse ($blogs as $index => $blog)
+            <tr>
+               <td>{{ ($blogs->currentPage() - 1) * $blogs->perPage() + $index + 1 }}</td>
+               <td>{{ $blog->qutation_id ?? '-' }}</td>
+               <td>{{ $blog->name }}</td>
+               <td>{{ $blog->category_name }}</td>
+               <td>{{ $blog->sub_name }}</td>
+               <td>{{ $blog->product_name }}</td>
+               <td>{{ $blog->bid_time }} day</td>
+               <td>{{ $blog->date_time ? \Carbon\Carbon::parse($blog->date_time)->format('d-m-Y') : '-' }}</td>
+               <td>{{ $blog->quantity }}</td>
+               <td>{{ $blog->unit }}</td>
+               <td>
+                  @if(!empty($blog->qutation_form_image))
+                     <a href="{{ url('seller/enquiry/file/'.$blog->id) }}" target="_blank">View</a>
+                  @else
+                     No file found
+                  @endif
+               </td>
+               <td>
+                  <span class="badge {{ $blog->status_badge === 'active' ? 'bg-success-subtle text-success' : 'bg-danger-subtle text-danger' }} py-1 px-2 fs-13">
+                     {{ $blog->status_badge }}
+                  </span>
+               </td>
+            </tr>
+         @empty
+            <tr>
+               <td colspan="12" class="text-center py-4">No enquiries found.</td>
+            </tr>
+         @endforelse
+      </tbody>
+   </table>
+</div>
+
+@if ($blogs->hasPages())
+   <div class="mt-3">
+      {{ $blogs->links('pagination::bootstrap-4') }}
+   </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\Frontend\BlogController;
 use App\Http\Controllers\Frontend\AjexResponseController;
 use App\Http\Controllers\URSController\ActiveEnquiryController;
+use App\Http\Controllers\URSController\MyEnquiryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -139,7 +140,7 @@ Route::get('/seller/accounting/totalshare', [App\Http\Controllers\SellerloginCon
 Route::get('/seller/enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
 Route::get('/seller/enquiry/bidding-data/{id}', [ActiveEnquiryController::class, 'biddingData'])->name('seller.enquiry.bidding-data');
 Route::get('/seller/enquiry/deactivelist', [App\Http\Controllers\SellerloginController::class, 'deactivelist']);
-Route::get('/seller/enquiry/myenclist', [App\Http\Controllers\SellerloginController::class, 'myenclist']);
+Route::get('/seller/enquiry/myenclist', [MyEnquiryController::class, 'index'])->name('seller.enquiry.my-enquiry');
 Route::post('/seller/update_lat_long', [App\Http\Controllers\SellerloginController::class, 'update_lat_long'])->name('update_lat_long');
 Route::post('/openqotationpage', [ActiveEnquiryController::class, 'openQuotationPage'])->name('openqotationpage');
 Route::post('/bidding_price', [App\Http\Controllers\SellerloginController::class, 'bidding_price'])->name('bidding_price');


### PR DESCRIPTION
## Summary
- add a dedicated MyEnquiryController for seller self-enquiries with filtering and pagination support
- create URS dashboard list and table partial views for the My Enquiry page
- update the seller enquiry route to point to the new controller

## Testing
- php -l app/Http/Controllers/URSController/MyEnquiryController.php

------
https://chatgpt.com/codex/tasks/task_e_68da4e6f26508327a7a64c5f82178915