### PR TITLE
Update seller enquiry URLs

### DIFF
--- a/app/Http/Controllers/SellerloginController.php
+++ b/app/Http/Controllers/SellerloginController.php
@@ -932,7 +932,7 @@ class SellerloginController extends Controller
             ->exists();
 
         if ($existingRecord) {
-            return response()->make("<script>alert('You have already paid for this.'); window.location.href = '" . url('seller/enquiry/list')->previous() . "';</script>");
+            return response()->make("<script>alert('You have already paid for this.'); window.location.href = '" . url('seller/active-enquiry/list')->previous() . "';</script>");
         } else {
             $merchantId = 'M22I5XAFXIGHT';
             $apiKey = '096dcc76-f0d9-41f3-93c8-f54c7b506668';
@@ -1078,7 +1078,7 @@ class SellerloginController extends Controller
                 curl_close($curl);
             }
 
-            return redirect('seller/enquiry/list')->with('success', 'Successfully  completed payment');
+            return redirect('seller/active-enquiry/list')->with('success', 'Successfully  completed payment');
     
         } else {
             $statusCode = $request->code ?? 'UNKNOWN_ERROR';
@@ -1104,7 +1104,7 @@ class SellerloginController extends Controller
                 'provider_reference_id' => $request->providerReferenceId ?? null,
             ]);
 
-            return redirect('seller/enquiry/list')->with('error', $message);
+            return redirect('seller/active-enquiry/list')->with('error', $message);
         }
     }
 

--- a/resources/views/admin/accounting-ad/view.blade.php
+++ b/resources/views/admin/accounting-ad/view.blade.php
@@ -30,7 +30,7 @@
 
 
                         <div class="action-btn">
-                            <a href="{{ url('seller/enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div>
                     </div>

--- a/resources/views/admin/buyer-order/accepted-list.blade.php
+++ b/resources/views/admin/buyer-order/accepted-list.blade.php
@@ -30,7 +30,7 @@
 
 
                         <!-- <div class="action-btn">
-                            <a href="{{ url('seller/enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div> -->
                     </div>

--- a/resources/views/admin/enquiry/view.blade.php
+++ b/resources/views/admin/enquiry/view.blade.php
@@ -30,7 +30,7 @@
 
 
                         <div class="action-btn">
-                            <a href="{{ url('seller/enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div>
                     </div>

--- a/resources/views/seller/accounting/view.blade.php
+++ b/resources/views/seller/accounting/view.blade.php
@@ -30,7 +30,7 @@
 
 
                         <div class="action-btn">
-                            <a href="{{ url('seller/enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div>
                     </div>

--- a/resources/views/seller/buyer-order/accepted-list.blade.php
+++ b/resources/views/seller/buyer-order/accepted-list.blade.php
@@ -30,7 +30,7 @@
 
 
                         <!-- <div class="action-btn">
-                            <a href="{{ url('seller/enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div> -->
                     </div>

--- a/resources/views/seller/enquiry/list.blade.php
+++ b/resources/views/seller/enquiry/list.blade.php
@@ -176,7 +176,7 @@
                         <!-- Reset Button -->
                         <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
                            <label class="form-label d-none d-lg-block">&nbsp;</label>
-                           <a href="{{ url('seller/enquiry/list') }}" class="btn btn-outline-secondary w-100">
+                           <a href="{{ url('seller/active-enquiry/list') }}" class="btn btn-outline-secondary w-100">
                               <i class="bi bi-arrow-counterclockwise me-2"></i>Reset Filters
                            </a>
                         </div>

--- a/resources/views/seller/enquiry/myenclist.blade.php
+++ b/resources/views/seller/enquiry/myenclist.blade.php
@@ -149,7 +149,7 @@
                               <button type="submit" class="btn btn-primary flex-fill">
                               <i class="bi bi-funnel-fill me-2"></i>Apply Filters
                               </button>
-                              <a href="{{ url('seller/enquiry/myenclist') }}" class="btn btn-outline-secondary flex-fill">
+                              <a href="{{ url('seller/my-enquiry/list') }}" class="btn btn-outline-secondary flex-fill">
                                  Reset
                               </a>
                            </div>

--- a/resources/views/seller/layouts/partials/sidebar.blade.php
+++ b/resources/views/seller/layouts/partials/sidebar.blade.php
@@ -53,26 +53,26 @@
             </li>
 
             <li class="nav-item">
-                <a class="nav-link menu-arrow {{ request()->is('seller/enquiry*') ? 'active' : '' }}" href="#sidebarEnquiry" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('seller/enquiry*') ? 'true' : 'false' }}" aria-controls="sidebarEnquiry">
+                <a class="nav-link menu-arrow {{ request()->is('seller/enquiry*', 'seller/active-enquiry*', 'seller/closed-enquiry*', 'seller/my-enquiry*') ? 'active' : '' }}" href="#sidebarEnquiry" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('seller/enquiry*', 'seller/active-enquiry*', 'seller/closed-enquiry*', 'seller/my-enquiry*') ? 'true' : 'false' }}" aria-controls="sidebarEnquiry">
                     <span class="nav-icon">
                         <i class="ri-question-answer-line"></i>
                     </span>
                     <span class="nav-text">Enquiries</span>
                 </a>
-                <div class="collapse {{ request()->is('seller/enquiry*') ? 'show' : '' }}" id="sidebarEnquiry">
+                <div class="collapse {{ request()->is('seller/enquiry*', 'seller/active-enquiry*', 'seller/closed-enquiry*', 'seller/my-enquiry*') ? 'show' : '' }}" id="sidebarEnquiry">
                     <ul class="nav sub-navbar-nav">
                         @if(in_array(1, $accTypeValues, true) || in_array(2, $accTypeValues, true))
                             <li class="sub-nav-item">
-                                <a class="sub-nav-link {{ request()->is('seller/enquiry/list') ? 'active' : '' }}" href="{{ url('seller/enquiry/list') }}">Active Enquiry List</a>
+                                <a class="sub-nav-link {{ request()->is('seller/active-enquiry/list') ? 'active' : '' }}" href="{{ url('seller/active-enquiry/list') }}">Active Enquiry List</a>
                             </li>
                             <li class="sub-nav-item">
-                                <a class="sub-nav-link {{ request()->is('seller/enquiry/deactivelist') ? 'active' : '' }}" href="{{ url('seller/enquiry/deactivelist') }}">Closed Enquiry List</a>
+                                <a class="sub-nav-link {{ request()->is('seller/closed-enquiry/list') ? 'active' : '' }}" href="{{ url('seller/closed-enquiry/list') }}">Closed Enquiry List</a>
                             </li>
                         @endif
 
                         @if(in_array(3, $accTypeValues, true) || in_array(4, $accTypeValues, true))
                             <li class="sub-nav-item">
-                                <a class="sub-nav-link {{ request()->is('seller/enquiry/myenclist') ? 'active' : '' }}" href="{{ url('seller/enquiry/myenclist') }}">My Enquiry List</a>
+                                <a class="sub-nav-link {{ request()->is('seller/my-enquiry/list') ? 'active' : '' }}" href="{{ url('seller/my-enquiry/list') }}">My Enquiry List</a>
                             </li>
                         @endif
                     </ul>

--- a/resources/views/ursdashboard/active-enquiry/openqotationpage.blade.php
+++ b/resources/views/ursdashboard/active-enquiry/openqotationpage.blade.php
@@ -136,7 +136,7 @@
 <script>
     document.getElementById("cancel-yes").addEventListener("click", function(event) {
         event.preventDefault(); // Prevent default link behavior
-        window.location.href = "{{ url('seller/enquiry/list') }}"; // Redirect
+        window.location.href = "{{ url('seller/active-enquiry/list') }}"; // Redirect
     });
 </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -138,10 +138,10 @@ Route::get('/seller/accounting/accbid', [App\Http\Controllers\SellerloginControl
 Route::get('/seller/accounting/biddrecive', [App\Http\Controllers\SellerloginController::class, 'biddrecive']);
 Route::get('/seller/accounting/list', [App\Http\Controllers\SellerloginController::class, 'accountinglist']);
 Route::get('/seller/accounting/totalshare', [App\Http\Controllers\SellerloginController::class, 'totalshare']);
-Route::get('/seller/enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
+Route::get('/seller/active-enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
 Route::get('/seller/enquiry/bidding-data/{id}', [ActiveEnquiryController::class, 'biddingData'])->name('seller.enquiry.bidding-data');
-Route::get('/seller/enquiry/deactivelist', [ClosedEnquiryController::class, 'index'])->name('seller.enquiry.closed');
-Route::get('/seller/enquiry/myenclist', [MyEnquiryController::class, 'index'])->name('seller.enquiry.my-enquiry');
+Route::get('/seller/closed-enquiry/list', [ClosedEnquiryController::class, 'index'])->name('seller.enquiry.closed');
+Route::get('/seller/my-enquiry/list', [MyEnquiryController::class, 'index'])->name('seller.enquiry.my-enquiry');
 Route::post('/seller/update_lat_long', [App\Http\Controllers\SellerloginController::class, 'update_lat_long'])->name('update_lat_long');
 Route::post('/openqotationpage', [ActiveEnquiryController::class, 'openQuotationPage'])->name('openqotationpage');
 Route::post('/bidding_price', [App\Http\Controllers\SellerloginController::class, 'bidding_price'])->name('bidding_price');


### PR DESCRIPTION
## Summary
- update seller enquiry routes to the new active, closed, and my enquiry URL patterns
- refresh seller/admin views and controller redirects to reference the renamed enquiry URLs
- adjust seller navigation highlighting to cover the updated enquiry paths

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da540bff988327bbebf0c79faea9fd