### PR TITLE
Restructure bidding received buyer order layout

### DIFF
--- a/app/Http/Controllers/URSController/BiddingReceivedController.php
+++ b/app/Http/Controllers/URSController/BiddingReceivedController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\URSController;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class BiddingReceivedController extends Controller
+{
+    /**
+     * Display the bidding received dashboard view.
+     */
+    public function index(Request $request)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (!$seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        return view('ursdashboard.bidding-received.list', [
+            'seller' => $seller,
+            'filters' => [],
+            'category_data' => collect(),
+            'records' => collect(),
+        ]);
+    }
+}

--- a/resources/views/ursdashboard/bidding-received/list.blade.php
+++ b/resources/views/ursdashboard/bidding-received/list.blade.php
@@ -1,0 +1,65 @@
+@extends('seller.layouts.app')
+@section('title', 'Bidding Received')
+
+@section('content')
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+@php
+    $sellerEmail = $seller->email ?? ($seller['email'] ?? '');
+    $filters = $filters ?? ($datas ?? []);
+    $categories = $category_data ?? [];
+    $records = $records ?? ($data ?? collect());
+    $buyerOrderBaseUrl = route('buyer-dashboard');
+@endphp
+<div class="container-fluid">
+    <div class="social-dash-wrap">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="breadcrumb-main">
+                    <h4 class="text-capitalize breadcrumb-title">Bidding Received</h4>
+                </div>
+            </div>
+        </div>
+
+        @include('ursdashboard.bidding-received.partials.bidding-modal', ['sellerEmail' => $sellerEmail])
+
+        <div class="row">
+            <div class="col-lg-12 mb-30">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                        <h5 class="mb-0">Filter Bids</h5>
+                        <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#buyerOrderFilters" aria-expanded="true" aria-controls="buyerOrderFilters">
+                            Toggle Filters
+                        </button>
+                    </div>
+
+                    <div class="collapse show" id="buyerOrderFilters">
+                        <div class="card-body">
+                            @include('ursdashboard.bidding-received.partials.filters', [
+                                'action' => $buyerOrderBaseUrl,
+                                'filters' => $filters,
+                                'categories' => $categories,
+                            ])
+                        </div>
+                    </div>
+                </div>
+
+                @include('ursdashboard.bidding-received.partials.alerts')
+
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <div id="buyerOrderTable">
+                            @include('ursdashboard.bidding-received.partials.table', [
+                                'records' => $records,
+                                'filters' => $filters,
+                            ])
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@include('ursdashboard.bidding-received.partials.scripts')
+@endsection

--- a/resources/views/ursdashboard/bidding-received/partials/alerts.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/alerts.blade.php
@@ -1,0 +1,24 @@
+@if(Session::has('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        {{ Session::get('success') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif
+
+@if(Session::has('error'))
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ Session::get('error') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif
+
+@if ($errors->any())
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif

--- a/resources/views/ursdashboard/bidding-received/partials/bidding-modal.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/bidding-modal.blade.php
@@ -1,0 +1,24 @@
+<div class="modal fade" id="buyerBidModal" tabindex="-1" role="dialog" aria-labelledby="buyerBidModalTitle"
+    aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="buyerBidModalTitle">Submit Bidding Price</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form action="{{ url('/bidding_price') }}" method="POST">
+                    @csrf
+                    <input type="hidden" value="{{ $sellerEmail }}" name="seller_email">
+                    <input type="hidden" name="product_id" class="product_id form-control">
+                    <input type="hidden" name="product_name" class="product_name form-control">
+                    <input type="hidden" name="user_email" class="user_email form-control">
+                    <input type="hidden" name="data_id" class="data_id form-control">
+                    <label class="form-label">Enter Price</label>
+                    <input type="text" name="price" required class="price form-control" placeholder="Enter Price">
+                    <button type="submit" class="btn btn-primary mt-3">Submit</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/ursdashboard/bidding-received/partials/filters.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/filters.blade.php
@@ -1,0 +1,77 @@
+@php
+    $filters = $filters ?? [];
+    $categories = $categories ?? [];
+@endphp
+<form id="buyerOrderFiltersForm" class="row g-3 align-items-end" method="get" action="{{ $action }}">
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Category</label>
+        <select name="category" id="buyerOrderCategory" class="form-select">
+            <option value="">Select Category</option>
+            @foreach($categories as $cat)
+                @php
+                    $categoryId = is_object($cat) ? ($cat->id ?? null) : ($cat['id'] ?? null);
+                    $categoryLabel = is_object($cat)
+                        ? ($cat->name ?? $cat->title ?? '')
+                        : ($cat['name'] ?? $cat['title'] ?? '');
+                @endphp
+                <option value="{{ $categoryId }}" {{ ($filters['category'] ?? '') == $categoryId ? 'selected' : '' }}>
+                    {{ $categoryLabel }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Date</label>
+        <input type="text" name="date" id="buyerOrderDate" class="form-control" placeholder="Date"
+            value="{{ $filters['date'] ?? '' }}">
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">City</label>
+        <input type="text" name="city" id="buyerOrderCity" class="form-control" placeholder="City"
+            value="{{ $filters['city'] ?? '' }}">
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Quantity</label>
+        <input type="text" name="quantity" id="buyerOrderQuantity" class="form-control" placeholder="Quantity"
+            value="{{ $filters['quantity'] ?? '' }}">
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Product Name</label>
+        <input type="text" name="product_name" id="buyerOrderProduct" class="form-control" placeholder="Product Name"
+            value="{{ $filters['product_name'] ?? '' }}">
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Quotation ID</label>
+        <input type="text" name="qutation_id" id="buyerOrderQuotation" class="form-control" placeholder="Quotation ID"
+            value="{{ $filters['qutation_id'] ?? '' }}">
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label">Records Per Page</label>
+        <select name="r_page" id="buyerOrderRecords" class="form-select">
+            @php
+                $perPage = (int) ($filters['r_page'] ?? 25);
+            @endphp
+            <option value="25" {{ $perPage === 25 ? 'selected' : '' }}>25</option>
+            <option value="50" {{ $perPage === 50 ? 'selected' : '' }}>50</option>
+            <option value="100" {{ $perPage === 100 ? 'selected' : '' }}>100</option>
+        </select>
+    </div>
+
+    <div class="col-12 col-sm-6 col-lg-3">
+        <label class="form-label d-none d-lg-block">&nbsp;</label>
+        <div class="d-flex flex-column flex-sm-row flex-lg-column flex-xl-row gap-2">
+            <button type="submit" class="btn btn-primary w-100 flex-fill">
+                <i class="bi bi-funnel-fill me-2"></i>Apply
+            </button>
+            <button type="button" id="resetBuyerOrderFilters" class="btn btn-outline-secondary w-100 flex-fill">
+                <i class="bi bi-arrow-counterclockwise me-2"></i>Reset
+            </button>
+        </div>
+    </div>
+</form>

--- a/resources/views/ursdashboard/bidding-received/partials/scripts.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/scripts.blade.php
@@ -1,0 +1,27 @@
+@push('scripts')
+<script type="text/javascript">
+    (function ($) {
+        const $form = $('#buyerOrderFiltersForm');
+        const $recordsPerPage = $('#buyerOrderRecords');
+        const $resetButton = $('#resetBuyerOrderFilters');
+
+        $recordsPerPage.on('change', function () {
+            $form.trigger('submit');
+        });
+
+        $resetButton.on('click', function () {
+            $form.find('input[type="text"]').val('');
+            $form.find('select').prop('selectedIndex', 0);
+            $form.trigger('submit');
+        });
+
+        $(document).on('click', '.mdl_btn', function () {
+            const $button = $(this);
+            $('.product_id').val($button.data('product_id'));
+            $('.product_name').val($button.data('product_name'));
+            $('.user_email').val($button.data('user_email'));
+            $('.data_id').val($button.data('data_id'));
+        });
+    })(jQuery);
+</script>
+@endpush

--- a/resources/views/ursdashboard/bidding-received/partials/table.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/table.blade.php
@@ -1,0 +1,101 @@
+@php
+    $filters = $filters ?? [];
+    $records = $records ?? collect();
+    if (is_array($records)) {
+        $records = collect($records);
+    }
+    $isPaginator = $records instanceof \Illuminate\Contracts\Pagination\Paginator;
+    $recordsForDisplay = $isPaginator ? collect($records->items()) : ($records instanceof \Illuminate\Support\Collection ? $records : collect());
+    $hasRecords = $recordsForDisplay->isNotEmpty();
+    $rowNumber = $isPaginator ? $records->firstItem() : 1;
+@endphp
+
+@if (!$hasRecords)
+    <div class="text-danger">Sorry, no bids found!</div>
+@else
+    <div class="table-responsive">
+        <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+            <thead>
+                <tr>
+                    <th><span class="projectDatatable-title">Sr.No</span></th>
+                    <th><span class="projectDatatable-title">Name</span></th>
+                    <th><span class="projectDatatable-title">Category</span></th>
+                    <th><span class="projectDatatable-title">Sub Category</span></th>
+                    <th><span class="projectDatatable-title">Product Name</span></th>
+                    <th><span class="projectDatatable-title">Date</span></th>
+                    <th><span class="projectDatatable-title">Quantity</span></th>
+                    <th><span class="projectDatatable-title">Unit</span></th>
+                    <th><span class="projectDatatable-title">Action</span></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($recordsForDisplay as $record)
+                    @php
+                        $recordId = is_object($record) ? ($record->id ?? null) : ($record['id'] ?? null);
+                        $recordName = is_object($record) ? ($record->name ?? '') : ($record['name'] ?? '');
+                        $recordCategory = is_object($record) ? ($record->category_name ?? '') : ($record['category_name'] ?? '');
+                        $recordSubCategory = is_object($record) ? ($record->sub_name ?? '') : ($record['sub_name'] ?? '');
+                        $recordProduct = is_object($record) ? ($record->product_name ?? '') : ($record['product_name'] ?? '');
+                        $recordDate = is_object($record) ? ($record->date_time ?? null) : ($record['date_time'] ?? null);
+                        $recordQuantity = is_object($record) ? ($record->quantity ?? '') : ($record['quantity'] ?? '');
+                        $recordUnit = is_object($record) ? ($record->unit ?? '') : ($record['unit'] ?? '');
+                        $formattedDate = $recordDate ? \Carbon\Carbon::parse($recordDate)->format('Y-m-d') : '';
+                    @endphp
+                    <tr>
+                        <td>
+                            <div class="userDatatable-content">{{ $rowNumber++ }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordName }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordCategory }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordSubCategory }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordProduct }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $formattedDate }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordQuantity }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordUnit }}</div>
+                        </td>
+                        <td class="d-flex gap-2">
+                            <a href="{{ $recordId ? url('/price-list/' . $recordId) : '#' }}" class="btn btn-primary btn-sm">
+                                View List
+                            </a>
+                            <a href="{{ $recordId ? url('/accepted-list/' . $recordId) : '#' }}" class="btn btn-success btn-sm">
+                                Accepted List
+                            </a>
+                            <button type="button" class="btn btn-outline-secondary btn-sm mdl_btn" data-bs-toggle="modal"
+                                data-bs-target="#buyerBidModal"
+                                data-product_id="{{ $recordId }}"
+                                data-product_name="{{ $recordProduct }}"
+                                data-user_email="{{ is_object($record) ? ($record->user_email ?? '') : ($record['user_email'] ?? '') }}"
+                                data-data_id="{{ $recordId }}">
+                                Bid Now
+                            </button>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    @if($isPaginator && $records->hasPages())
+        <div class="gmz-pagination mt-3">
+            @if(!empty($filters))
+                {{ $records->appends($filters)->links('pagination::bootstrap-4') }}
+            @else
+                {{ $records->links('pagination::bootstrap-4') }}
+            @endif
+        </div>
+    @endif
+@endif
+


### PR DESCRIPTION
## Summary
- refactor the bidding received blade to mirror the active enquiry structure with modular partials
- add dedicated partials for filters, alerts, modal, table, and scripts to prepare buyer order UI
- update the bidding received controller to provide default datasets expected by the new view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da56b4665483279f475d2493993333