### PR TITLE
Show quotation ID on buyer order table

### DIFF
--- a/app/Http/Controllers/URSController/BiddingReceivedController.php
+++ b/app/Http/Controllers/URSController/BiddingReceivedController.php
@@ -60,6 +60,7 @@ class BiddingReceivedController extends Controller
                 'qutation_form.unit as unit',
                 'qutation_form.quantity as quantity',
                 'qutation_form.status as qutation_form_status',
+                'qutation_form.qutation_id as qutation_id',
                 'seller.id as seller_id',
                 'seller.email as seller_email',
                 'seller.name as seller_name',

--- a/resources/views/ursdashboard/bidding-received/partials/table.blade.php
+++ b/resources/views/ursdashboard/bidding-received/partials/table.blade.php
@@ -18,6 +18,7 @@
             <thead>
                 <tr>
                     <th><span class="projectDatatable-title">Sr.No</span></th>
+                    <th><span class="projectDatatable-title">Quotation ID</span></th>
                     <th><span class="projectDatatable-title">Name</span></th>
                     <th><span class="projectDatatable-title">Category</span></th>
                     <th><span class="projectDatatable-title">Sub Category</span></th>
@@ -33,6 +34,7 @@
                     @php
                         $recordId = is_object($record) ? ($record->id ?? null) : ($record['id'] ?? null);
                         $recordName = is_object($record) ? ($record->name ?? '') : ($record['name'] ?? '');
+                        $recordQuotationId = is_object($record) ? ($record->qutation_id ?? '') : ($record['qutation_id'] ?? '');
                         $recordCategory = is_object($record) ? ($record->category_name ?? '') : ($record['category_name'] ?? '');
                         $recordSubCategory = is_object($record) ? ($record->sub_name ?? '') : ($record['sub_name'] ?? '');
                         $recordProduct = is_object($record) ? ($record->product_name ?? '') : ($record['product_name'] ?? '');
@@ -44,6 +46,9 @@
                     <tr>
                         <td>
                             <div class="userDatatable-content">{{ $rowNumber++ }}</div>
+                        </td>
+                        <td>
+                            <div class="userDatatable-content">{{ $recordQuotationId ?: '-' }}</div>
                         </td>
                         <td>
                             <div class="userDatatable-content">{{ $recordName }}</div>


### PR DESCRIPTION
## Summary
- include the quotation identifier in the buyer order query results
- display the quotation ID column within the bidding received list table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8286deac8327a8ca77a852f3de4e