### PR TITLE
Update buyer bidding routes to new URLs

### DIFF
--- a/resources/views/admin/buyer-order/view.blade.php
+++ b/resources/views/admin/buyer-order/view.blade.php
@@ -30,7 +30,7 @@
 
 
                         <div class="action-btn">
-                            <a href="{{ url('/buyer-order') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('buyer/bidding-received/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div>
                     </div>

--- a/resources/views/seller/buyer-order/view.blade.php
+++ b/resources/views/seller/buyer-order/view.blade.php
@@ -30,7 +30,7 @@
 
 
                         <div class="action-btn">
-                            <a href="{{ url('/buyer-order') }}" class="btn btn-sm btn-primary btn-add">
+                            <a href="{{ url('buyer/bidding-received/list') }}" class="btn btn-sm btn-primary btn-add">
                                 <i class="la la-plus"></i> Back</a>
                         </div>
                     </div>

--- a/resources/views/seller/layouts/partials/sidebar.blade.php
+++ b/resources/views/seller/layouts/partials/sidebar.blade.php
@@ -80,23 +80,23 @@
             </li>
 
             <li class="nav-item">
-                <a class="nav-link menu-arrow {{ request()->is('buyer-order*') ? 'active' : '' }}" href="#sidebarBidding" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('buyer-order*') ? 'true' : 'false' }}" aria-controls="sidebarBidding">
+                <a class="nav-link menu-arrow {{ request()->is('buyer/bidding-received*', 'buyer/my-bidding*', 'buyer-order/acc-list') ? 'active' : '' }}" href="#sidebarBidding" data-bs-toggle="collapse" role="button" aria-expanded="{{ request()->is('buyer/bidding-received*', 'buyer/my-bidding*', 'buyer-order/acc-list') ? 'true' : 'false' }}" aria-controls="sidebarBidding">
                     <span class="nav-icon">
                         <i class="ri-auction-line"></i>
                     </span>
                     <span class="nav-text">Bidding</span>
                 </a>
-                <div class="collapse {{ request()->is('buyer-order*') ? 'show' : '' }}" id="sidebarBidding">
+                <div class="collapse {{ request()->is('buyer/bidding-received*', 'buyer/my-bidding*', 'buyer-order/acc-list') ? 'show' : '' }}" id="sidebarBidding">
                     <ul class="nav sub-navbar-nav">
                         @if(in_array(3, $accTypeValues, true) || in_array(4, $accTypeValues, true))
                             <li class="sub-nav-item">
-                                <a class="sub-nav-link {{ request()->is('buyer-order') ? 'active' : '' }}" href="{{ url('buyer-order') }}">Bidding Received</a>
+                                <a class="sub-nav-link {{ request()->is('buyer/bidding-received/list') ? 'active' : '' }}" href="{{ url('buyer/bidding-received/list') }}">Bidding Received</a>
                             </li>
                         @endif
 
                         @if(in_array(1, $accTypeValues, true) || in_array(2, $accTypeValues, true))
                             <li class="sub-nav-item">
-                                <a class="sub-nav-link {{ request()->is('buyer-order/mylist') ? 'active' : '' }}" href="{{ route('buyer-order.mylist') }}">My Bidding</a>
+                                <a class="sub-nav-link {{ request()->is('buyer/my-bidding/list') ? 'active' : '' }}" href="{{ route('buyer-order.mylist') }}">My Bidding</a>
                             </li>
                             <li class="sub-nav-item">
                                 <a class="sub-nav-link {{ request()->is('buyer-order/acc-list') ? 'active' : '' }}" href="{{ url('buyer-order/acc-list') }}">Accepted Bidding</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -152,8 +152,8 @@ Route::get('/viewwork/{id}', [App\Http\Controllers\SellerloginController::class,
 
 
 
-Route::get('/buyer-order', [App\Http\Controllers\URSController\BiddingReceivedController::class, 'index'])->name('buyer-dashboard');
-Route::get('/buyer-order/mylist', [App\Http\Controllers\URSController\MyBiddingController::class, 'index'])->name('buyer-order.mylist');
+Route::get('/buyer/bidding-received/list', [App\Http\Controllers\URSController\BiddingReceivedController::class, 'index'])->name('buyer-dashboard');
+Route::get('/buyer/my-bidding/list', [App\Http\Controllers\URSController\MyBiddingController::class, 'index'])->name('buyer-order.mylist');
 Route::get('/buyer-order/acc-list', [App\Http\Controllers\BuyerloginController::class, 'acc_list'])->name('acc-list');
 Route::get('/price-list/{data_id}', [App\Http\Controllers\BuyerloginController::class, 'price_list'])->name('price-list');
 Route::get('/accepted-list/{data_id}', [App\Http\Controllers\BuyerloginController::class, 'accepted_list'])->name('accepted-list');


### PR DESCRIPTION
## Summary
- update the buyer bidding routes to the new URL paths requested
- adjust sidebar navigation and related views to point to the updated buyer bidding URLs and highlight the correct menu items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9abe9e408327bdb9ab7048f8de54