### PR TITLE
Adjust closed enquiry filter inputs

### DIFF
--- a/resources/views/ursdashboard/closed-enquiry/list.blade.php
+++ b/resources/views/ursdashboard/closed-enquiry/list.blade.php
@@ -37,8 +37,12 @@
                            </select>
                         </div>
                         <div class="col-12 col-sm-6 col-lg-3">
+                           <label class="form-label">Quotation ID</label>
+                           <input type="text" name="qutation_id" class="form-control" placeholder="Quotation ID" value="{{ $data['qutation_id'] ?? '' }}">
+                        </div>
+                        <div class="col-12 col-sm-6 col-lg-3">
                            <label class="form-label">Date</label>
-                           <input type="text" name="date" class="form-control" placeholder="Date" value="{{ $data['date'] ?? '' }}">
+                           <input type="date" name="date" class="form-control" placeholder="Date" value="{{ $data['date'] ?? '' }}">
                         </div>
                         <div class="col-12 col-sm-6 col-lg-3">
                            <label class="form-label">City</label>
@@ -46,15 +50,11 @@
                         </div>
                         <div class="col-12 col-sm-6 col-lg-3">
                            <label class="form-label">Quantity</label>
-                           <input type="text" name="quantity" class="form-control" placeholder="Quantity" value="{{ $data['quantity'] ?? '' }}">
+                           <input type="number" name="quantity" class="form-control" placeholder="Quantity" value="{{ $data['quantity'] ?? '' }}" min="1" step="1" inputmode="numeric">
                         </div>
                         <div class="col-12 col-sm-6 col-lg-3">
                            <label class="form-label">Product Name</label>
                            <input type="text" name="product_name" class="form-control" placeholder="Product Name" value="{{ $data['product_name'] ?? '' }}">
-                        </div>
-                        <div class="col-12 col-sm-6 col-lg-3">
-                           <label class="form-label">Quotation ID</label>
-                           <input type="text" name="qutation_id" class="form-control" placeholder="Quotation ID" value="{{ $data['qutation_id'] ?? '' }}">
                         </div>
                         <div class="col-12 col-sm-6 col-lg-3">
                            <label class="form-label">Records Per Page</label>


### PR DESCRIPTION
## Summary
- Move the Quotation ID filter next to the Category selector to match the desired layout
- Use a native date picker for the date filter and restrict the quantity field to positive numbers

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc2ed7a5d88327b5493f3c4fed06d2