### PR TITLE
Fix sitemap.xml 404 by serving static file

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,19 @@ Route::get('/clear-cache', function () {
     return 'All caches cleared!';
 })->name('clear.cache');
 
+Route::get('/sitemap.xml', function () {
+    $path = public_path('sitemap.xml');
+
+    if (! file_exists($path)) {
+        abort(404);
+    }
+
+    return response()->file($path, [
+        'Content-Type' => 'application/xml',
+        'Cache-Control' => 'public, max-age=3600',
+    ]);
+});
+
 // Route to display the email form
 Route::get('/test', [EmailController::class, 'showForm'])->name('email.form');
 


### PR DESCRIPTION
## Summary
- add a dedicated route that serves the generated sitemap.xml from the public directory
- return a 404 if the sitemap file is missing and send appropriate XML caching headers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e23eef33848327b0369ddb5d314ee3