### PR TITLE
Add dedicated controller and views for seller accounting list

### DIFF
--- a/app/Http/Controllers/URSController/AccountingTotalBiddingController.php
+++ b/app/Http/Controllers/URSController/AccountingTotalBiddingController.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Http\Controllers\URSController;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class AccountingTotalBiddingController extends Controller
+{
+    public function index(Request $request)
+    {
+        $seller = $request->session()->get('seller');
+
+        if (! $seller) {
+            abort(403, 'Seller session not found.');
+        }
+
+        $perPage = (int) $request->input('r_page', 25);
+
+        $filters = [
+            'category' => $request->input('category'),
+            'date' => $request->input('date'),
+            'city' => $request->input('city'),
+            'quantity' => $request->input('quantity'),
+            'product_name' => $request->input('product_name'),
+            'r_page' => $perPage,
+        ];
+
+        $query = $this->baseTotalBiddingQuery($seller->email);
+
+        if ($request->filled('category')) {
+            $query->where('c.id', $request->input('category'));
+        }
+
+        if ($request->filled('date')) {
+            $date = $this->parseDate($request->input('date'));
+            if ($date) {
+                $query->whereDate('qutation_form.date_time', $date);
+            }
+        }
+
+        if ($request->filled('city')) {
+            $query->where('qutation_form.city', 'like', '%' . $request->input('city') . '%');
+        }
+
+        if ($request->filled('quantity')) {
+            $query->where('qutation_form.quantity', 'like', '%' . $request->input('quantity') . '%');
+        }
+
+        if ($request->filled('product_name')) {
+            $productName = $request->input('product_name');
+            $query->where(function ($innerQuery) use ($productName) {
+                $innerQuery
+                    ->where('product.title', 'like', '%' . $productName . '%')
+                    ->orWhere('bidding_price.product_name', 'like', '%' . $productName . '%');
+            });
+        }
+
+        $records = $query
+            ->orderByDesc('bidding_price.id')
+            ->paginate($perPage)
+            ->withQueryString();
+
+        $records = $this->appendComputedState($records);
+
+        $categoryData = DB::table('categories')
+            ->select('id', 'name', DB::raw('name as title'))
+            ->orderBy('name')
+            ->get();
+
+        if ($request->ajax()) {
+            return view('ursdashboard.accounting.total-bidding.partials.table', [
+                'records' => $records,
+                'filters' => $filters,
+            ])->render();
+        }
+
+        return view('ursdashboard.accounting.total-bidding.list', [
+            'seller' => $seller,
+            'records' => $records,
+            'filters' => $filters,
+            'category_data' => $categoryData,
+        ]);
+    }
+
+    protected function baseTotalBiddingQuery(string $sellerEmail)
+    {
+        $productBrands = DB::table('product_brands')
+            ->select('product_id', DB::raw('MAX(brand_name) as brand_name'))
+            ->groupBy('product_id');
+
+        return DB::table('bidding_price')
+            ->leftJoin('seller', 'bidding_price.user_email', '=', 'seller.email')
+            ->leftJoin('product', 'bidding_price.product_id', '=', 'product.id')
+            ->leftJoinSub($productBrands, 'pb', function ($join) {
+                $join->on('product.id', '=', 'pb.product_id');
+            })
+            ->leftJoin('qutation_form', 'bidding_price.data_id', '=', 'qutation_form.id')
+            ->leftJoin('sub_categories as sc', 'product.sub_id', '=', 'sc.id')
+            ->leftJoin('categories as c', 'sc.category_id', '=', 'c.id')
+            ->where('bidding_price.seller_email', $sellerEmail)
+            ->where('bidding_price.payment_status', 'success')
+            ->select(
+                'bidding_price.id as bidding_id',
+                'bidding_price.price as platform_fee',
+                'bidding_price.rate as rate',
+                'bidding_price.action as action',
+                'bidding_price.product_name as requested_product_name',
+                'bidding_price.data_id as qutation_form_id',
+                'seller.name as buyer_name',
+                'seller.email as buyer_email',
+                'product.title as product_name',
+                'product.id as product_id',
+                'product.image as product_image',
+                'pb.brand_name as product_brand',
+                'qutation_form.qutation_id as qutation_id',
+                'qutation_form.name as qutation_form_name',
+                'qutation_form.date_time as date_time',
+                'qutation_form.quantity as quantity',
+                'qutation_form.unit as unit',
+                'qutation_form.city as city',
+                'sc.name as sub_name',
+                'c.name as category_name'
+            );
+    }
+
+    protected function appendComputedState(LengthAwarePaginator $records): LengthAwarePaginator
+    {
+        $transformed = $records->getCollection()->map(function ($record) {
+            $record = (object) $record;
+
+            $record->status_badge = $this->resolveStatusBadge($record->action ?? null);
+            $record->quantity_numeric = $this->extractNumericQuantity($record->quantity ?? null);
+
+            if (isset($record->rate) && $record->rate !== null) {
+                $record->total_price = $record->quantity_numeric * (float) $record->rate;
+            } else {
+                $record->total_price = null;
+            }
+
+            return $record;
+        });
+
+        $records->setCollection($transformed);
+
+        return $records;
+    }
+
+    protected function resolveStatusBadge(?string $action): string
+    {
+        return match ($action) {
+            'pending' => 'warning',
+            'rejected' => 'danger',
+            'completed', 'success' => 'success',
+            default => 'secondary',
+        };
+    }
+
+    protected function extractNumericQuantity($quantity): float
+    {
+        if (is_numeric($quantity)) {
+            return (float) $quantity;
+        }
+
+        if (is_string($quantity)) {
+            preg_match('/\d+(?:\.\d+)?/', $quantity, $matches);
+
+            if (! empty($matches[0])) {
+                return (float) $matches[0];
+            }
+        }
+
+        return 0.0;
+    }
+
+    protected function parseDate(?string $date): ?string
+    {
+        if (! $date) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($date)->format('Y-m-d');
+        } catch (\Exception $exception) {
+            return null;
+        }
+    }
+}

--- a/resources/views/ursdashboard/accounting/total-bidding/list.blade.php
+++ b/resources/views/ursdashboard/accounting/total-bidding/list.blade.php
@@ -1,0 +1,158 @@
+@extends('seller.layouts.app')
+@section('title', 'Total Bidding')
+
+@section('content')
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+@php
+    $filters = $filters ?? [];
+    $categories = $category_data ?? collect();
+    $records = $records ?? collect();
+    $listingUrl = route('seller.accounting.list');
+@endphp
+<div class="container-fluid">
+    <div class="social-dash-wrap">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="breadcrumb-main">
+                    <h4 class="text-capitalize breadcrumb-title">Total Bidding</h4>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-lg-12 mb-30">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header d-flex justify-content-between align-items-center border-bottom">
+                        <h5 class="mb-0">Filter Total Bids</h5>
+                        <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#sellerTotalBiddingFilters" aria-expanded="true" aria-controls="sellerTotalBiddingFilters">
+                            Toggle Filters
+                        </button>
+                    </div>
+
+                    <div class="collapse show" id="sellerTotalBiddingFilters">
+                        <div class="card-body">
+                            <form id="sellerTotalBiddingFiltersForm" class="row g-3 align-items-end" method="get" action="{{ $listingUrl }}">
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label">Category</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="bi bi-tags"></i></span>
+                                        <select name="category" class="form-select">
+                                            <option value="">Select Category</option>
+                                            @foreach($categories as $cat)
+                                                @php
+                                                    $categoryId = is_object($cat) ? ($cat->id ?? null) : ($cat['id'] ?? null);
+                                                    $categoryLabel = is_object($cat)
+                                                        ? ($cat->name ?? $cat->title ?? '')
+                                                        : ($cat['name'] ?? $cat['title'] ?? '');
+                                                @endphp
+                                                <option value="{{ $categoryId }}" {{ ($filters['category'] ?? '') == $categoryId ? 'selected' : '' }}>
+                                                    {{ $categoryLabel }}
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label">Date</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="bi bi-calendar-date"></i></span>
+                                        <input type="date" name="date" class="form-control" value="{{ $filters['date'] ?? '' }}">
+                                    </div>
+                                </div>
+
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label">City</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="bi bi-geo-alt"></i></span>
+                                        <input type="text" name="city" class="form-control" placeholder="City" value="{{ $filters['city'] ?? '' }}">
+                                    </div>
+                                </div>
+
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label">Quantity</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="bi bi-box"></i></span>
+                                        <input type="text" name="quantity" class="form-control" placeholder="Quantity" value="{{ $filters['quantity'] ?? '' }}">
+                                    </div>
+                                </div>
+
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label">Product Name</label>
+                                    <div class="input-group">
+                                        <span class="input-group-text"><i class="bi bi-bag"></i></span>
+                                        <input type="text" name="product_name" class="form-control" placeholder="Product Name" value="{{ $filters['product_name'] ?? '' }}">
+                                    </div>
+                                </div>
+
+                                <div class="col-12 col-sm-6 col-lg-3">
+                                    <label class="form-label d-none d-lg-block">&nbsp;</label>
+                                    <div class="d-flex flex-column flex-sm-row flex-lg-column flex-xl-row gap-2">
+                                        <button type="submit" class="btn btn-primary w-100 flex-fill">
+                                            <i class="bi bi-funnel-fill me-2"></i>Apply
+                                        </button>
+                                        <button type="button" id="resetSellerTotalBiddingFilters" class="btn btn-outline-secondary w-100 flex-fill">
+                                            <i class="bi bi-arrow-counterclockwise me-2"></i>Reset
+                                        </button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                @if(Session::has('success'))
+                    <div class="alert alert-success alert-dismissible fade show" role="alert">
+                        {{ Session::get('success') }}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                @endif
+
+                @if(Session::has('error'))
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                        {{ Session::get('error') }}
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                @endif
+
+                @if ($errors->any())
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                        <ul class="mb-0">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    </div>
+                @endif
+
+                <div class="card shadow-sm">
+                    <div class="card-body">
+                        <div id="sellerTotalBiddingTable">
+                            @include('ursdashboard.accounting.total-bidding.partials.table', [
+                                'records' => $records,
+                                'filters' => $filters,
+                            ])
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@push('scripts')
+<script type="text/javascript">
+    (function ($) {
+        const $form = $('#sellerTotalBiddingFiltersForm');
+        const $resetButton = $('#resetSellerTotalBiddingFilters');
+
+        $resetButton.on('click', function () {
+            $form.find('input[type="text"], input[type="date"]').val('');
+            $form.find('select').prop('selectedIndex', 0);
+            $form.trigger('submit');
+        });
+    })(jQuery);
+</script>
+@endpush
+@endsection

--- a/resources/views/ursdashboard/accounting/total-bidding/partials/table.blade.php
+++ b/resources/views/ursdashboard/accounting/total-bidding/partials/table.blade.php
@@ -1,0 +1,100 @@
+@php
+    $filters = $filters ?? [];
+    $records = $records ?? collect();
+    if (is_array($records)) {
+        $records = collect($records);
+    }
+    $isPaginator = $records instanceof \Illuminate\Contracts\Pagination\Paginator;
+    $recordsForDisplay = $isPaginator ? collect($records->items()) : ($records instanceof \Illuminate\Support\Collection ? $records : collect());
+    $rowNumber = $isPaginator ? $records->firstItem() : 1;
+@endphp
+<div class="table-responsive">
+    <table class="table align-middle text-nowrap table-hover table-centered mb-0">
+        <thead>
+            <tr>
+                <th>Sr.No</th>
+                <th>Quotation ID</th>
+                <th>Name</th>
+                <th>Category</th>
+                <th>Sub Category</th>
+                <th>Product Name</th>
+                <th>Date</th>
+                <th>City</th>
+                <th>Unit</th>
+                <th>Quantity</th>
+                <th>Rate</th>
+                <th>Total Price</th>
+                <th>Platform Fee</th>
+                <th>Status</th>
+                <th>Action</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($recordsForDisplay as $record)
+                @php
+                    $record = is_array($record) ? (object) $record : $record;
+                    $quotationId = $record->qutation_id ?? '';
+                    $name = $record->qutation_form_name ?? $record->buyer_name ?? '';
+                    $category = $record->category_name ?? '';
+                    $subCategory = $record->sub_name ?? '';
+                    $productName = $record->requested_product_name ?? $record->product_name ?? '';
+                    $dateValue = $record->date_time ?? null;
+                    $formattedDate = $dateValue ? \Carbon\Carbon::parse($dateValue)->format('Y-m-d') : '';
+                    $city = $record->city ?? '';
+                    $unit = $record->unit ?? '';
+                    $quantityRaw = $record->quantity ?? '';
+                    $rate = $record->rate ?? null;
+                    $totalPrice = $record->total_price ?? null;
+                    $platformFee = $record->platform_fee ?? null;
+                    $statusBadge = $record->status_badge ?? 'secondary';
+                    $qutationFormId = $record->qutation_form_id ?? null;
+                @endphp
+                <tr>
+                    <td>{{ $rowNumber++ }}</td>
+                    <td>{{ $quotationId ?: '-' }}</td>
+                    <td>{{ $name ?: '-' }}</td>
+                    <td>{{ $category ?: '-' }}</td>
+                    <td>{{ $subCategory ?: '-' }}</td>
+                    <td>{{ $productName ?: '-' }}</td>
+                    <td>{{ $formattedDate ?: '-' }}</td>
+                    <td>{{ $city ?: '-' }}</td>
+                    <td>{{ $unit ?: '-' }}</td>
+                    <td>{{ $quantityRaw ?: '-' }}</td>
+                    <td>{{ $rate !== null ? number_format((float) $rate, 2) : '-' }}</td>
+                    <td>{{ $totalPrice !== null ? number_format($totalPrice, 2) : '-' }}</td>
+                    <td>{{ $platformFee !== null ? number_format((float) $platformFee, 2) : '-' }}</td>
+                    <td>
+                        <span class="badge bg-{{ $statusBadge }} text-capitalize">
+                            {{ $statusBadge }}
+                        </span>
+                    </td>
+                    <td>
+                        <div class="d-flex gap-2">
+                            @if($qutationFormId)
+                                <a href="{{ url('seller/enquiry/view/' . $qutationFormId) }}" class="btn btn-primary btn-sm">
+                                    View Details
+                                </a>
+                            @else
+                                <span class="text-muted">-</span>
+                            @endif
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="15" class="text-center py-4">No bids found.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+
+@if($isPaginator && $records->hasPages())
+    <div class="gmz-pagination mt-3">
+        @if(!empty($filters))
+            {{ $records->appends($filters)->links('pagination::bootstrap-4') }}
+        @else
+            {{ $records->links('pagination::bootstrap-4') }}
+        @endif
+    </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -149,7 +149,7 @@ Route::get('/seller/buyer-order/file/{any}', [App\Http\Controllers\BuyerloginCon
 
 Route::get('/seller/accounting/accbid', [App\Http\Controllers\SellerloginController::class, 'accbid']);
 Route::get('/seller/accounting/biddrecive', [App\Http\Controllers\URSController\AccountingBiddingReceivedController::class, 'index'])->name('seller.accounting.biddrecive');
-Route::get('/seller/accounting/list', [App\Http\Controllers\SellerloginController::class, 'accountinglist']);
+Route::get('/seller/accounting/list', [App\Http\Controllers\URSController\AccountingTotalBiddingController::class, 'index'])->name('seller.accounting.list');
 Route::get('/seller/accounting/totalshare', [App\Http\Controllers\SellerloginController::class, 'totalshare']);
 Route::get('/seller/active-enquiry/list/{id?}', [ActiveEnquiryController::class, 'index'])->name('seller.enquiry.list');
 Route::get('/seller/enquiry/bidding-data/{id}', [ActiveEnquiryController::class, 'biddingData'])->name('seller.enquiry.bidding-data');


### PR DESCRIPTION
## Summary
- introduce AccountingTotalBiddingController to encapsulate seller accounting list filters and data loading
- add redesigned seller accounting total bidding views with reusable table partials
- route seller accounting list URL through the new controller for consistency with other accounting pages

## Testing
- php -l app/Http/Controllers/URSController/AccountingTotalBiddingController.php

------
https://chatgpt.com/codex/tasks/task_e_68e4029d9fd48327a8a48fc92b1eaef7