### PR TITLE
Add filters to buyer price list page

### DIFF
--- a/app/Http/Controllers/URSController/PriceListController.php
+++ b/app/Http/Controllers/URSController/PriceListController.php
@@ -18,7 +18,28 @@ class PriceListController extends Controller
             abort(403, 'Seller session not found.');
         }
 
-        $records = $this->basePriceListQuery($seller->email, $dataId)
+        $baseQuery = $this->basePriceListQuery($seller->email, $dataId);
+
+        $allRecords = $this->appendComputedState(
+            $baseQuery
+                ->orderByDesc('bidding_price.id')
+                ->get()
+        );
+
+        $filters = [
+            'category'     => $request->input('category'),
+            'sub_category' => $request->input('sub_category'),
+            'product_name' => $request->input('product_name'),
+            'quotation_id' => $request->input('quotation_id'),
+            'date'         => $request->input('date'),
+            'city'         => $request->input('city'),
+            'quantity'     => $request->input('quantity'),
+        ];
+
+        $records = $this->applyFilters(
+            $this->basePriceListQuery($seller->email, $dataId),
+            $filters
+        )
             ->orderByDesc('bidding_price.id')
             ->get();
 
@@ -33,6 +54,8 @@ class PriceListController extends Controller
             'total'           => $records->count(),
             'enquiryId'       => $dataId,
             'cisQuotationId'  => $cisQuotationId,
+            'filters'         => $filters,
+            'filterOptions'   => $this->buildFilterOptions($allRecords),
         ]);
     }
 
@@ -351,7 +374,63 @@ class PriceListController extends Controller
             return $sellerId === 0 || !in_array($sellerId, $existingSellerIds, true);
         });
 
-        return $merged->merge($remaining)->values();
+            return $merged->merge($remaining)->values();
+    }
+
+    protected function applyFilters($query, array $filters)
+    {
+        $normalizeDate = function ($value) {
+            if (blank($value)) {
+                return null;
+            }
+
+            try {
+                return Carbon::parse($value)->toDateString();
+            } catch (\Throwable $e) {
+                return $value;
+            }
+        };
+
+        return $query
+            ->when($filters['category'], function ($query, $categoryId) {
+                return $query->where('c.id', (int) $categoryId);
+            })
+            ->when($filters['sub_category'], function ($query, $subCategoryId) {
+                return $query->where('sc.id', (int) $subCategoryId);
+            })
+            ->when($filters['product_name'], function ($query, $productName) {
+                $productName = trim((string) $productName);
+
+                return $query->where(function ($subQuery) use ($productName) {
+                    $subQuery
+                        ->where('product.title', 'LIKE', "%{$productName}%")
+                        ->orWhere('bidding_price.product_name', 'LIKE', "%{$productName}%");
+                });
+            })
+            ->when($filters['quotation_id'], function ($query, $quotationId) {
+                $quotationId = trim((string) $quotationId);
+
+                return $query->where('qutation_form.qutation_id', 'LIKE', "%{$quotationId}%");
+            })
+            ->when($filters['date'], function ($query, $date) use ($normalizeDate) {
+                $normalizedDate = $normalizeDate($date);
+
+                if (!$normalizedDate) {
+                    return $query;
+                }
+
+                return $query->whereDate('qutation_form.date_time', $normalizedDate);
+            })
+            ->when($filters['city'], function ($query, $city) {
+                $city = trim((string) $city);
+
+                return $query->where('qutation_form.city', 'LIKE', "%{$city}%");
+            })
+            ->when($filters['quantity'], function ($query, $quantity) {
+                $quantity = trim((string) $quantity);
+
+                return $query->where('qutation_form.quantity', 'LIKE', "%{$quantity}%");
+            });
     }
 
     protected function hydrateEnquiryContext(?object $record, object $quotationForm): object
@@ -468,5 +547,73 @@ class PriceListController extends Controller
 
             return $record;
         });
+    }
+
+    protected function buildFilterOptions(Collection $records): array
+    {
+        $resolveProductName = function ($record) {
+            return collect([
+                $record->product_title ?? null,
+                $record->bidding_price_product_name ?? null,
+            ])->filter()->first();
+        };
+
+        $categories = $records
+            ->map(fn ($record) => [
+                'id' => $record->category_id ?? null,
+                'name' => $record->category_name ?? null,
+            ])
+            ->filter(fn ($option) => filled($option['id']) && filled($option['name']))
+            ->unique('id')
+            ->values();
+
+        $subCategories = $records
+            ->map(fn ($record) => [
+                'id' => $record->sub_id ?? null,
+                'name' => $record->sub_name ?? null,
+            ])
+            ->filter(fn ($option) => filled($option['id']) && filled($option['name']))
+            ->unique('id')
+            ->values();
+
+        $products = $records
+            ->map(function ($record) use ($resolveProductName) {
+                return [
+                    'id' => $record->product_id ?? $record->bidding_price_product_id ?? null,
+                    'name' => $resolveProductName($record),
+                ];
+            })
+            ->filter(fn ($option) => filled($option['name']))
+            ->unique(function ($option) {
+                return strtolower($option['name']);
+            })
+            ->values();
+
+        $dates = $records
+            ->map(fn ($record) => $record->formatted_date ?? null)
+            ->filter()
+            ->unique()
+            ->values();
+
+        $cities = $records
+            ->map(fn ($record) => $record->qutation_form_city ?? null)
+            ->filter()
+            ->unique()
+            ->values();
+
+        $quantities = $records
+            ->map(fn ($record) => $record->quantity ?? null)
+            ->filter()
+            ->unique()
+            ->values();
+
+        return [
+            'categories'    => $categories,
+            'subCategories' => $subCategories,
+            'products'      => $products,
+            'dates'         => $dates,
+            'cities'        => $cities,
+            'quantities'    => $quantities,
+        ];
     }
 }

--- a/resources/views/ursdashboard/price-list/partials/table.blade.php
+++ b/resources/views/ursdashboard/price-list/partials/table.blade.php
@@ -3,8 +3,105 @@
     if (!($records instanceof \Illuminate\Support\Collection)) {
         $records = collect($records);
     }
+
+    $filters = $filters ?? [
+        'category' => request('category'),
+        'sub_category' => request('sub_category'),
+        'product_name' => request('product_name'),
+        'quotation_id' => request('quotation_id'),
+        'date' => request('date'),
+        'city' => request('city'),
+        'quantity' => request('quantity'),
+    ];
+
+    $filterOptions = $filterOptions ?? [
+        'categories' => collect(),
+        'subCategories' => collect(),
+        'products' => collect(),
+        'dates' => collect(),
+        'cities' => collect(),
+        'quantities' => collect(),
+    ];
+
     $hasRecords = $records->isNotEmpty();
 @endphp
+<div class="card mb-4 shadow-none border">
+    <div class="card-body pb-0">
+        <form class="row gy-3" method="GET" action="{{ route('buyer.price-list', $enquiryId) }}">
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Category</label>
+                <select name="category" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['categories'] as $category)
+                        <option value="{{ $category['id'] }}" {{ $filters['category'] == $category['id'] ? 'selected' : '' }}>
+                            {{ $category['name'] }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Sub Category</label>
+                <select name="sub_category" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['subCategories'] as $subCategory)
+                        <option value="{{ $subCategory['id'] }}" {{ $filters['sub_category'] == $subCategory['id'] ? 'selected' : '' }}>
+                            {{ $subCategory['name'] }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Product Name</label>
+                <select name="product_name" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['products'] as $product)
+                        <option value="{{ $product['name'] }}" {{ $filters['product_name'] == $product['name'] ? 'selected' : '' }}>
+                            {{ $product['name'] }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Quotation ID</label>
+                <input type="text" name="quotation_id" value="{{ $filters['quotation_id'] }}" class="form-control"
+                    placeholder="Enter quotation id">
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Date</label>
+                <select name="date" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['dates'] as $date)
+                        <option value="{{ $date }}" {{ $filters['date'] == $date ? 'selected' : '' }}>{{ $date }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">City</label>
+                <select name="city" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['cities'] as $city)
+                        <option value="{{ $city }}" {{ $filters['city'] == $city ? 'selected' : '' }}>{{ $city }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-md-6">
+                <label class="form-label fw-semibold">Quantity</label>
+                <select name="quantity" class="form-select">
+                    <option value="">All</option>
+                    @foreach ($filterOptions['quantities'] as $quantity)
+                        <option value="{{ $quantity }}" {{ $filters['quantity'] == $quantity ? 'selected' : '' }}>
+                            {{ $quantity }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-12 d-flex gap-2 justify-content-end">
+                <button type="submit" class="btn btn-primary">Apply</button>
+                <a href="{{ route('buyer.price-list', $enquiryId) }}" class="btn btn-outline-secondary">Reset</a>
+            </div>
+        </form>
+    </div>
+</div>
 <div class="table-responsive">
     <table class="table align-middle text-nowrap table-hover table-centered mb-0">
         <thead class="table-light">

--- a/resources/views/ursdashboard/price-list/show.blade.php
+++ b/resources/views/ursdashboard/price-list/show.blade.php
@@ -37,6 +37,9 @@
                         @include('ursdashboard.price-list.partials.table', [
                             'records' => $records,
                             'total' => $total,
+                            'filters' => $filters,
+                            'filterOptions' => $filterOptions,
+                            'enquiryId' => $enquiryId,
                         ])
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add filter handling for buyer price list queries, including category, sub-category, product, quotation ID, date, city, and quantity
- build available filter option lists from the current enquiry records
- render a filter form with apply and reset controls above the seller price list table

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6ff750c88327a870145031c01a32)